### PR TITLE
Fix typos and address field in repo

### DIFF
--- a/src/repository/test.rs
+++ b/src/repository/test.rs
@@ -18,7 +18,7 @@ impl ClientRepository for TestClientRepository {
             name: new_client.name.clone(),
             email: new_client.email.clone(),
             phone: new_client.phone.clone(),
-            address: new_client.phone.clone(),
+            address: new_client.address.clone(),
             ..Client::default()
         };
 
@@ -66,7 +66,7 @@ impl ClientRepository for TestClientRepository {
             name: updates.name.clone(),
             email: updates.email.clone(),
             phone: updates.phone.clone(),
-            address: updates.phone.clone(),
+            address: updates.address.clone(),
             ..Client::default()
         };
 

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -52,7 +52,7 @@ fn ensure_role(
 
 fn render_template(template: &str, context: &Context) -> HttpResponse {
     HttpResponse::Ok().body(TEMPLATES.render(template, context).unwrap_or_else(|e| {
-        error!("Failed to render template {}': {}", template, e);
+        error!("Failed to render template '{}': {}", template, e);
         String::new()
     }))
 }


### PR DESCRIPTION
## Summary
- correct the log message around template rendering
- fix address assignments in `TestClientRepository`

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_686b84fd87b0832fbf96b1b6109ca405