### PR TITLE
Add cleanup assertions in db test

### DIFF
--- a/tests/db.rs
+++ b/tests/db.rs
@@ -2,7 +2,16 @@ mod common;
 
 #[test]
 fn test_creates_and_removes_db_files() {
-    let test_db = common::TestDb::new("test_in_memory_connection.db");
-    let conn = test_db.pool().get();
-    assert!(conn.is_ok());
+    let base = "test_in_memory_connection.db";
+
+    {
+        let test_db = common::TestDb::new(base);
+        let conn = test_db.pool().get();
+        assert!(conn.is_ok());
+    }
+
+    let db_path = std::path::Path::new(base);
+    assert!(!db_path.exists());
+    assert!(!std::path::Path::new(&format!("{base}-shm")).exists());
+    assert!(!std::path::Path::new(&format!("{base}-wal")).exists());
 }


### PR DESCRIPTION
## Summary
- verify that SQLite files are deleted after `TestDb` is dropped
- refactor to reuse `base` variable for file name

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_686ce1ae4784832f89193c940a7ddc4a