### PR TITLE
Add unit tests for core modules

### DIFF
--- a/src/models/auth.rs
+++ b/src/models/auth.rs
@@ -47,6 +47,44 @@ impl AuthenticatedUser {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use jsonwebtoken::{DecodingKey, Validation, decode};
+
+    fn sample_user() -> AuthenticatedUser {
+        AuthenticatedUser {
+            sub: "1".to_string(),
+            email: "test@example.com".to_string(),
+            hub_id: 1,
+            name: "Test".to_string(),
+            roles: vec!["crm".to_string()],
+            exp: 0,
+        }
+    }
+
+    #[test]
+    fn jwt_round_trip() {
+        let secret = "secret";
+        let mut user = sample_user();
+        let token = user.to_jwt(secret).unwrap();
+        let decoded = decode::<AuthenticatedUser>(
+            &token,
+            &DecodingKey::from_secret(secret.as_bytes()),
+            &Validation::default(),
+        )
+        .unwrap()
+        .claims;
+
+        assert_eq!(decoded.sub, user.sub);
+        assert_eq!(decoded.email, user.email);
+        assert_eq!(decoded.hub_id, user.hub_id);
+        assert_eq!(decoded.name, user.name);
+        assert_eq!(decoded.roles, user.roles);
+        assert_eq!(decoded.exp, user.exp);
+    }
+}
+
 impl FromRequest for AuthenticatedUser {
     type Error = Error;
     type Future = Ready<Result<Self, Self::Error>>;

--- a/src/models/client.rs
+++ b/src/models/client.rs
@@ -89,3 +89,68 @@ impl<'a> From<DomainUpdateClient<'a>> for UpdateClient<'a> {
         Self::from(&client)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_domain_new() -> DomainNewClient<'static> {
+        DomainNewClient {
+            hub_id: 1,
+            name: "John",
+            email: "john@example.com",
+            phone: "123",
+            address: "addr",
+        }
+    }
+
+    #[test]
+    fn from_domain_new_creates_newclient() {
+        let domain = sample_domain_new();
+        let new: NewClient = (&domain).into();
+        assert_eq!(new.hub_id, domain.hub_id);
+        assert_eq!(new.name, domain.name);
+        assert_eq!(new.email, domain.email);
+        assert_eq!(new.phone, domain.phone);
+        assert_eq!(new.address, domain.address);
+    }
+
+    #[test]
+    fn from_domain_update_creates_updateclient() {
+        let domain = DomainUpdateClient {
+            name: "Jane",
+            email: "jane@example.com",
+            phone: "321",
+            address: "addr2",
+        };
+        let update: UpdateClient = (&domain).into();
+        assert_eq!(update.name, domain.name);
+        assert_eq!(update.email, domain.email);
+        assert_eq!(update.phone, domain.phone);
+        assert_eq!(update.address, domain.address);
+    }
+
+    #[test]
+    fn client_into_domain() {
+        let now = NaiveDateTime::from_timestamp_opt(0, 0).unwrap();
+        let db_client = Client {
+            id: 1,
+            hub_id: 2,
+            name: "n".into(),
+            email: "e".into(),
+            phone: "p".into(),
+            address: "a".into(),
+            created_at: now,
+            updated_at: now,
+        };
+        let domain: DomainClient = db_client.into();
+        assert_eq!(domain.id, 1);
+        assert_eq!(domain.hub_id, 2);
+        assert_eq!(domain.name, "n");
+        assert_eq!(domain.email, "e");
+        assert_eq!(domain.phone, "p");
+        assert_eq!(domain.address, "a");
+        assert_eq!(domain.created_at, now);
+        assert_eq!(domain.updated_at, now);
+    }
+}

--- a/src/models/manager.rs
+++ b/src/models/manager.rs
@@ -131,3 +131,42 @@ impl From<DomainNewClientManager> for NewClientManager {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_domain_newmanager() {
+        let domain = DomainNewManager {
+            hub_id: 1,
+            name: "Alice",
+            email: "a@b.c",
+        };
+        let new: NewManager = (&domain).into();
+        assert_eq!(new.hub_id, domain.hub_id);
+        assert_eq!(new.name, domain.name);
+        assert_eq!(new.email, domain.email);
+
+        let update: UpdateManager = (&domain).into();
+        assert_eq!(update.name, domain.name);
+
+        let update_from_new: UpdateManager = new.into();
+        assert_eq!(update_from_new.name, domain.name);
+    }
+
+    #[test]
+    fn from_manager_into_domain() {
+        let db = Manager {
+            id: 1,
+            hub_id: 2,
+            name: "Bob".into(),
+            email: "b@c.d".into(),
+        };
+        let domain: DomainManager = db.into();
+        assert_eq!(domain.id, 1);
+        assert_eq!(domain.hub_id, 2);
+        assert_eq!(domain.name, "Bob");
+        assert_eq!(domain.email, "b@c.d");
+    }
+}

--- a/src/pagination.rs
+++ b/src/pagination.rs
@@ -57,3 +57,40 @@ impl<T> Paginated<T> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pages_without_ellipses() {
+        let pages = get_pages(10, 5, 2, 2, 4, 2);
+        let expected = (1..=10).map(Some).collect::<Vec<_>>();
+        assert_eq!(pages, expected);
+    }
+
+    #[test]
+    fn pages_with_ellipses() {
+        let pages = get_pages(100, 1, 2, 2, 4, 2);
+        assert_eq!(
+            pages,
+            vec![
+                Some(1),
+                Some(2),
+                Some(3),
+                Some(4),
+                Some(5),
+                None,
+                Some(99),
+                Some(100),
+            ]
+        );
+    }
+
+    #[test]
+    fn paginated_sets_page_to_one_when_zero() {
+        let paginated: Paginated<i32> = Paginated::new(vec![1, 2, 3], 0, 3);
+        assert_eq!(paginated.page, 1);
+        assert_eq!(paginated.pages, vec![Some(1), Some(2), Some(3)]);
+    }
+}

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -65,3 +65,22 @@ fn render_template(template: &str, context: &Context) -> HttpResponse {
         String::new()
     }))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use actix_web::http::StatusCode;
+
+    #[test]
+    fn check_role_detects_role() {
+        assert!(check_role("admin", &["user", "admin"]));
+        assert!(!check_role("admin", &["user", "manager"]));
+    }
+
+    #[test]
+    fn redirect_sets_location_header() {
+        let resp = redirect("/target");
+        assert_eq!(resp.status(), StatusCode::SEE_OTHER);
+        assert_eq!(resp.headers().get(header::LOCATION).unwrap(), "/target");
+    }
+}


### PR DESCRIPTION
## Summary
- test pagination functionality and `Paginated` struct
- test helper functions in `routes` module
- test JWT round‑trips for `AuthenticatedUser`
- test conversions for client and manager domain models

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6872743b1ffc832f9cae93ef568a75e6