### PR TITLE
Fix pagination search query

### DIFF
--- a/templates/pagination.html
+++ b/templates/pagination.html
@@ -6,7 +6,7 @@
                 {% if page %}
                     {% if page != items.page %}
                         <li class="page-item">
-                        <a class="page-link" href="?page={{page}}">
+                        <a class="page-link" href="?page={{page}}{% if search_query %}&q={{search_query}}{% endif %}">
                                 {{ page }}
                             </a>
                         </li>


### PR DESCRIPTION
## Summary
- preserve the search query parameter when navigating pagination links

## Testing
- `cargo clippy`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_687960ab8fdc832fadbec71cbbbbca7a