### PR TITLE
Add pages_empty_when_no_pages test

### DIFF
--- a/src/pagination.rs
+++ b/src/pagination.rs
@@ -93,4 +93,10 @@ mod tests {
         assert_eq!(paginated.page, 1);
         assert_eq!(paginated.pages, vec![Some(1), Some(2), Some(3)]);
     }
+
+    #[test]
+    fn pages_empty_when_no_pages() {
+        let pages = get_pages(0, 1, 2, 2, 4, 2);
+        assert!(pages.is_empty());
+    }
 }


### PR DESCRIPTION
## Summary
- add a new test `pages_empty_when_no_pages`
- assert `get_pages` returns an empty vector when there are no pages

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6879ca575d54832fb3181cc2450a670e