### PR TITLE
Fix manager model doc path

### DIFF
--- a/src/models/manager.rs
+++ b/src/models/manager.rs
@@ -9,7 +9,7 @@ use crate::models::client::Client;
 
 #[derive(Debug, Clone, Identifiable, Queryable)]
 #[diesel(table_name = crate::schema::managers)]
-/// Diesel model for [`crate::domain::client::Manager`].
+/// Diesel model for [`crate::domain::manager::Manager`].
 pub struct Manager {
     pub id: i32,
     pub hub_id: i32,


### PR DESCRIPTION
## Summary
- fix doc comment for `src/models/manager.rs` to reference `crate::domain::manager::Manager`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6879ca5360e0832fbbad0cd707bc1f75