### PR TITLE
Log error reasons while keeping Russian flash messages

### DIFF
--- a/src/routes/client.rs
+++ b/src/routes/client.rs
@@ -116,7 +116,8 @@ pub async fn save_client(
     }
 
     if let Err(e) = form.validate() {
-        FlashMessage::error(format!("Ошибка валидации формы: {e}")).send();
+        error!("Failed to validate form: {e}");
+        FlashMessage::error("Ошибка валидации формы").send();
         return redirect(&format!("/client/{}", form.id));
     }
 
@@ -138,7 +139,7 @@ pub async fn save_client(
         }
         Err(err) => {
             error!("Failed to update client: {err}");
-            FlashMessage::error(format!("Ошибка при обновлении клиента: {err}")).send();
+            FlashMessage::error("Ошибка при обновлении клиента").send();
         }
     }
 
@@ -156,7 +157,8 @@ pub async fn comment_client(
     }
 
     if let Err(e) = form.validate() {
-        FlashMessage::error(format!("Ошибка валидации формы: {e}")).send();
+        error!("Failed to validate form: {e}");
+        FlashMessage::error("Ошибка валидации формы").send();
         return redirect(&format!("/client/{}", form.id));
     }
 
@@ -199,7 +201,7 @@ pub async fn comment_client(
         }
         Err(err) => {
             error!("Failed to update client: {err}");
-            FlashMessage::error(format!("Ошибка при добавлении события: {err}")).send();
+            FlashMessage::error("Ошибка при добавлении события").send();
         }
     }
 
@@ -217,7 +219,8 @@ pub async fn attachment_client(
     }
 
     if let Err(e) = form.validate() {
-        FlashMessage::error(format!("Ошибка валидации формы: {e}")).send();
+        error!("Failed to validate form: {e}");
+        FlashMessage::error("Ошибка валидации формы").send();
         return redirect(&format!("/client/{}", form.id));
     }
 
@@ -261,7 +264,7 @@ pub async fn attachment_client(
         }
         Err(err) => {
             error!("Failed to update client: {err}");
-            FlashMessage::error(format!("Ошибка при добавлении события: {err}")).send();
+            FlashMessage::error("Ошибка при добавлении события").send();
         }
     }
 

--- a/src/routes/main.rs
+++ b/src/routes/main.rs
@@ -105,7 +105,8 @@ pub async fn add_client(
     };
 
     if let Err(e) = form.validate() {
-        FlashMessage::error(format!("Ошибка валидации формы: {e}")).send();
+        error!("Failed to validate form: {e}");
+        FlashMessage::error("Ошибка валидации формы").send();
         return redirect("/");
     }
 
@@ -118,7 +119,7 @@ pub async fn add_client(
         }
         Err(err) => {
             error!("Failed to add a client: {err}");
-            FlashMessage::error(format!("Ошибка при добавлении клиента: {err}")).send();
+            FlashMessage::error("Ошибка при добавлении клиента").send();
         }
     }
     redirect("/")
@@ -158,7 +159,8 @@ pub async fn clients_upload(
     let clients = match form.parse(user.hub_id) {
         Ok(clients) => clients,
         Err(err) => {
-            FlashMessage::error(format!("Ошибка при парсинге клиентов: {err}")).send();
+            error!("Failed to parse clients: {err}");
+            FlashMessage::error("Ошибка при парсинге клиентов").send();
             return redirect("/");
         }
     };
@@ -169,7 +171,7 @@ pub async fn clients_upload(
         }
         Err(err) => {
             error!("Failed to add clients: {err}");
-            FlashMessage::error(format!("Ошибка при добавлении клиентов: {err}")).send();
+            FlashMessage::error("Ошибка при добавлении клиентов").send();
         }
     }
 

--- a/src/routes/managers.rs
+++ b/src/routes/managers.rs
@@ -61,7 +61,8 @@ pub async fn add_manager(
     };
 
     if let Err(e) = form.validate() {
-        FlashMessage::error(format!("Ошибка валидации формы: {e}")).send();
+        error!("Failed to validate form: {e}");
+        FlashMessage::error("Ошибка валидации формы").send();
         return redirect("/managers");
     }
 
@@ -78,7 +79,7 @@ pub async fn add_manager(
         }
         Err(err) => {
             error!("Failed to save the manager: {err}");
-            FlashMessage::error(format!("Ошибка при добавлении менеджера: {err}")).send();
+            FlashMessage::error("Ошибка при добавлении менеджера").send();
         }
     }
     redirect("/managers")
@@ -135,7 +136,8 @@ pub async fn assign_manager(
     let form: AssignManagerForm = match serde_html_form::from_bytes(&form) {
         Ok(form) => form,
         Err(err) => {
-            FlashMessage::error(format!("Ошибка при обработке формы: {err}")).send();
+            error!("Failed to process form: {err}");
+            FlashMessage::error("Ошибка при обработке формы").send();
             return redirect("/managers");
         }
     };
@@ -147,7 +149,7 @@ pub async fn assign_manager(
         }
         Err(err) => {
             error!("Failed to assign clients to the manager: {err}");
-            FlashMessage::error(format!("Ошибка при назначении клиентов менеджера: {err}")).send();
+            FlashMessage::error("Ошибка при назначении клиентов менеджера").send();
         }
     }
     redirect("/managers")


### PR DESCRIPTION
## Summary
- show static Russian error messages in the UI
- record error details in English via `log::error!`

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68835a02295c832fbf76dfe9eb6a132c