### PR TITLE
feat: extend client FTS with optional fields

### DIFF
--- a/migrations/2025-09-16-120000_update_client_fts_optional_fields/down.sql
+++ b/migrations/2025-09-16-120000_update_client_fts_optional_fields/down.sql
@@ -1,0 +1,31 @@
+-- Revert client_fts back to original structure without optional fields
+DROP TRIGGER IF EXISTS client_fields_ai;
+DROP TRIGGER IF EXISTS client_fields_au;
+DROP TRIGGER IF EXISTS client_fields_ad;
+DROP TRIGGER IF EXISTS clients_ai;
+DROP TRIGGER IF EXISTS clients_au;
+DROP TRIGGER IF EXISTS clients_ad;
+DROP TABLE IF EXISTS client_fts;
+
+CREATE VIRTUAL TABLE client_fts USING fts5(
+    name,
+    email,
+    phone,
+    address,
+    content='clients',
+    content_rowid='id',
+    tokenize = 'unicode61'
+);
+
+INSERT INTO client_fts(client_fts) VALUES('rebuild');
+
+CREATE TRIGGER clients_ai AFTER INSERT ON clients BEGIN
+  INSERT INTO client_fts(rowid, name, email, phone, address) VALUES (new.id, new.name, new.email, new.phone, new.address);
+END;
+CREATE TRIGGER clients_ad AFTER DELETE ON clients BEGIN
+  INSERT INTO client_fts(client_fts, rowid, name, email, phone, address) VALUES('delete', old.id, old.name, old.email, old.phone, old.address);
+END;
+CREATE TRIGGER clients_au AFTER UPDATE ON clients BEGIN
+  INSERT INTO client_fts(client_fts, rowid, name, email, phone, address) VALUES('delete', old.id, old.name, old.email, old.phone, old.address);
+  INSERT INTO client_fts(rowid, name, email, phone, address) VALUES (new.id, new.name, new.email, new.phone, new.address);
+END;

--- a/migrations/2025-09-16-120000_update_client_fts_optional_fields/up.sql
+++ b/migrations/2025-09-16-120000_update_client_fts_optional_fields/up.sql
@@ -1,0 +1,77 @@
+-- Recreate client_fts to include optional client fields
+DROP TRIGGER IF EXISTS clients_ai;
+DROP TRIGGER IF EXISTS clients_au;
+DROP TRIGGER IF EXISTS clients_ad;
+DROP TRIGGER IF EXISTS client_fields_ai;
+DROP TRIGGER IF EXISTS client_fields_au;
+DROP TRIGGER IF EXISTS client_fields_ad;
+DROP TABLE IF EXISTS client_fts;
+
+CREATE VIRTUAL TABLE client_fts USING fts5(
+    name,
+    email,
+    phone,
+    address,
+    fields,
+    tokenize = 'unicode61'
+);
+
+INSERT INTO client_fts(rowid, name, email, phone, address, fields)
+SELECT
+    clients.id,
+    clients.name,
+    clients.email,
+    clients.phone,
+    clients.address,
+    COALESCE(group_concat(client_fields.value, ' '), '')
+FROM clients
+LEFT JOIN client_fields ON clients.id = client_fields.client_id
+GROUP BY clients.id;
+
+CREATE TRIGGER clients_ai AFTER INSERT ON clients BEGIN
+  INSERT INTO client_fts(rowid, name, email, phone, address, fields)
+  VALUES (
+    new.id,
+    new.name,
+    new.email,
+    new.phone,
+    new.address,
+    COALESCE((SELECT group_concat(value, ' ') FROM client_fields WHERE client_id = new.id), '')
+  );
+END;
+
+CREATE TRIGGER clients_ad AFTER DELETE ON clients BEGIN
+  INSERT INTO client_fts(client_fts, rowid, name, email, phone, address, fields)
+  VALUES (
+    'delete',
+    old.id,
+    old.name,
+    old.email,
+    old.phone,
+    old.address,
+    COALESCE((SELECT group_concat(value, ' ') FROM client_fields WHERE client_id = old.id), '')
+  );
+END;
+
+CREATE TRIGGER clients_au AFTER UPDATE ON clients BEGIN
+  INSERT INTO client_fts(client_fts, rowid, name, email, phone, address, fields)
+  VALUES (
+    'delete',
+    old.id,
+    old.name,
+    old.email,
+    old.phone,
+    old.address,
+    COALESCE((SELECT group_concat(value, ' ') FROM client_fields WHERE client_id = old.id), '')
+  );
+  INSERT INTO client_fts(rowid, name, email, phone, address, fields)
+  VALUES (
+    new.id,
+    new.name,
+    new.email,
+    new.phone,
+    new.address,
+    COALESCE((SELECT group_concat(value, ' ') FROM client_fields WHERE client_id = new.id), '')
+  );
+END;
+

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -26,6 +26,7 @@ diesel::table! {
         email -> Nullable<Binary>,
         phone -> Nullable<Binary>,
         address -> Nullable<Binary>,
+        fields -> Nullable<Binary>,
         #[sql_name = "client_fts"]
         client_fts_col -> Nullable<Binary>,
         rank -> Nullable<Binary>,


### PR DESCRIPTION
## Summary
- add migration to index optional client fields in FTS
- expose fields column in Diesel schema
- refresh FTS after client field updates without extra no-op update

## Testing
- `cargo test` *(fails: test_client_repository_crud panicked: DatabaseError("SQL logic error"))*

------
https://chatgpt.com/codex/tasks/task_e_68b2f44adb6c832a9ff153a448aca5ea