### PR TITLE
Normalize user emails on creation

### DIFF
--- a/src/domain/client.rs
+++ b/src/domain/client.rs
@@ -28,12 +28,50 @@ pub struct NewClient {
     pub fields: Option<HashMap<String, String>>,
 }
 
+impl NewClient {
+    pub fn new(
+        hub_id: i32,
+        name: String,
+        email: String,
+        phone: String,
+        address: String,
+        fields: Option<HashMap<String, String>>,
+    ) -> Self {
+        Self {
+            hub_id,
+            name,
+            email: email.to_lowercase(),
+            phone,
+            address,
+            fields,
+        }
+    }
+}
+
 #[derive(Clone, Debug, Deserialize)]
-pub struct UpdateClient<'a> {
-    pub name: &'a str,
-    pub email: &'a str,
-    pub phone: &'a str,
-    pub address: &'a str,
+pub struct UpdateClient {
+    pub name: String,
+    pub email: String,
+    pub phone: String,
+    pub address: String,
     /// Updated map of custom fields.
-    pub fields: HashMap<&'a str, &'a str>,
+    pub fields: HashMap<String, String>,
+}
+
+impl UpdateClient {
+    pub fn new(
+        name: String,
+        email: String,
+        phone: String,
+        address: String,
+        fields: HashMap<String, String>,
+    ) -> Self {
+        Self {
+            name,
+            email: email.to_lowercase(),
+            phone,
+            address,
+            fields,
+        }
+    }
 }

--- a/src/domain/manager.rs
+++ b/src/domain/manager.rs
@@ -10,10 +10,20 @@ pub struct Manager {
 }
 
 #[derive(Clone, Debug, Deserialize)]
-pub struct NewManager<'a> {
+pub struct NewManager {
     pub hub_id: i32,
-    pub name: &'a str,
-    pub email: &'a str,
+    pub name: String,
+    pub email: String,
+}
+
+impl NewManager {
+    pub fn new(hub_id: i32, name: String, email: String) -> Self {
+        Self {
+            hub_id,
+            name,
+            email: email.to_lowercase(),
+        }
+    }
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -33,12 +43,8 @@ pub struct NewClientManager {
     pub manager_id: i32,
 }
 
-impl<'a> From<&'a AuthenticatedUser> for NewManager<'a> {
-    fn from(value: &'a AuthenticatedUser) -> Self {
-        NewManager {
-            name: &value.name,
-            email: &value.email,
-            hub_id: value.hub_id,
-        }
+impl From<&AuthenticatedUser> for NewManager {
+    fn from(value: &AuthenticatedUser) -> Self {
+        NewManager::new(value.hub_id, value.name.clone(), value.email.clone())
     }
 }

--- a/src/domain/manager.rs
+++ b/src/domain/manager.rs
@@ -27,8 +27,8 @@ impl NewManager {
 }
 
 #[derive(Clone, Debug, Deserialize)]
-pub struct UpdateManager<'a> {
-    pub name: &'a str,
+pub struct UpdateManager {
+    pub name: String,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]

--- a/src/forms/client.rs
+++ b/src/forms/client.rs
@@ -51,22 +51,22 @@ pub struct AddAttachmentForm {
     pub url: String,
 }
 
-impl<'a> From<&'a SaveClientForm> for UpdateClient<'a> {
+impl From<&SaveClientForm> for UpdateClient {
     /// Convert the [`SaveClientForm`] into an [`UpdateClient`] value for persistence.
-    fn from(form: &'a SaveClientForm) -> Self {
-        let fields: HashMap<&str, &str> = form
+    fn from(form: &SaveClientForm) -> Self {
+        let fields: HashMap<String, String> = form
             .field
             .iter()
             .zip(form.value.iter())
-            .map(|(k, v)| (k.as_str(), v.as_str()))
+            .map(|(k, v)| (k.clone(), v.clone()))
             .collect();
 
-        Self {
-            name: &form.name,
-            email: &form.email,
-            phone: &form.phone,
-            address: &form.address,
+        UpdateClient::new(
+            form.name.clone(),
+            form.email.clone(),
+            form.phone.clone(),
+            form.address.clone(),
             fields,
-        }
+        )
     }
 }

--- a/src/forms/client.rs
+++ b/src/forms/client.rs
@@ -51,9 +51,9 @@ pub struct AddAttachmentForm {
     pub url: String,
 }
 
-impl From<&SaveClientForm> for UpdateClient {
+impl From<SaveClientForm> for UpdateClient {
     /// Convert the [`SaveClientForm`] into an [`UpdateClient`] value for persistence.
-    fn from(form: &SaveClientForm) -> Self {
+    fn from(form: SaveClientForm) -> Self {
         let fields: HashMap<String, String> = form
             .field
             .iter()
@@ -61,12 +61,6 @@ impl From<&SaveClientForm> for UpdateClient {
             .map(|(k, v)| (k.clone(), v.clone()))
             .collect();
 
-        UpdateClient::new(
-            form.name.clone(),
-            form.email.clone(),
-            form.phone.clone(),
-            form.address.clone(),
-            fields,
-        )
+        UpdateClient::new(form.name, form.email, form.phone, form.address, fields)
     }
 }

--- a/src/forms/main.rs
+++ b/src/forms/main.rs
@@ -26,14 +26,14 @@ pub struct AddClientForm {
 
 impl From<AddClientForm> for NewClient {
     fn from(form: AddClientForm) -> Self {
-        Self {
-            hub_id: form.hub_id,
-            name: form.name,
-            email: form.email,
-            phone: form.phone,
-            address: form.address,
-            fields: None,
-        }
+        NewClient::new(
+            form.hub_id,
+            form.name,
+            form.email,
+            form.phone,
+            form.address,
+            None,
+        )
     }
 }
 
@@ -90,7 +90,7 @@ impl UploadClientsForm {
             for (i, field) in record.iter().enumerate() {
                 match headers.get(i) {
                     Some("name") => name = field.trim().to_string(),
-                    Some("email") => email = field.trim().to_lowercase(),
+                    Some("email") => email = field.trim().to_string(),
                     Some("phone") => phone = field.trim().to_string(),
                     Some("address") => address = field.trim().to_string(),
                     Some(header) => {
@@ -108,14 +108,14 @@ impl UploadClientsForm {
                 continue;
             }
 
-            clients.push(NewClient {
+            clients.push(NewClient::new(
                 hub_id,
                 name,
                 email,
                 phone,
                 address,
-                fields: Some(optional_fields),
-            });
+                Some(optional_fields),
+            ));
         }
 
         Ok(clients)

--- a/src/models/client.rs
+++ b/src/models/client.rs
@@ -86,20 +86,14 @@ impl<'a> From<&'a DomainNewClient> for NewClient<'a> {
     }
 }
 
-impl<'a> From<&DomainUpdateClient<'a>> for UpdateClient<'a> {
-    fn from(client: &DomainUpdateClient<'a>) -> Self {
+impl<'a> From<&'a DomainUpdateClient> for UpdateClient<'a> {
+    fn from(client: &'a DomainUpdateClient) -> Self {
         Self {
-            name: client.name,
-            email: client.email,
-            phone: client.phone,
-            address: client.address,
+            name: client.name.as_str(),
+            email: client.email.as_str(),
+            phone: client.phone.as_str(),
+            address: client.address.as_str(),
         }
-    }
-}
-
-impl<'a> From<DomainUpdateClient<'a>> for UpdateClient<'a> {
-    fn from(client: DomainUpdateClient<'a>) -> Self {
-        Self::from(&client)
     }
 }
 
@@ -111,14 +105,14 @@ mod tests {
     use chrono::Utc;
 
     fn sample_domain_new() -> DomainNewClient {
-        DomainNewClient {
-            hub_id: 1,
-            name: "John".to_string(),
-            email: "john@example.com".to_string(),
-            phone: "123".to_string(),
-            address: "addr".to_string(),
-            fields: None,
-        }
+        DomainNewClient::new(
+            1,
+            "John".to_string(),
+            "john@example.com".to_string(),
+            "123".to_string(),
+            "addr".to_string(),
+            None,
+        )
     }
 
     #[test]
@@ -134,13 +128,13 @@ mod tests {
 
     #[test]
     fn from_domain_update_creates_updateclient() {
-        let domain = DomainUpdateClient {
-            name: "Jane",
-            email: "jane@example.com",
-            phone: "321",
-            address: "addr2",
-            fields: HashMap::new(),
-        };
+        let domain = DomainUpdateClient::new(
+            "Jane".to_string(),
+            "jane@example.com".to_string(),
+            "321".to_string(),
+            "addr2".to_string(),
+            HashMap::new(),
+        );
         let update: UpdateClient = (&domain).into();
         assert_eq!(update.name, domain.name);
         assert_eq!(update.email, domain.email);

--- a/src/models/manager.rs
+++ b/src/models/manager.rs
@@ -73,9 +73,11 @@ impl<'a> From<&'a DomainNewManager> for NewManager<'a> {
     }
 }
 
-impl<'a> From<&'a DomainUpdateManager<'a>> for UpdateManager<'a> {
-    fn from(manager: &'a DomainUpdateManager<'a>) -> Self {
-        Self { name: manager.name }
+impl<'a> From<&'a DomainUpdateManager> for UpdateManager<'a> {
+    fn from(manager: &'a DomainUpdateManager) -> Self {
+        Self {
+            name: manager.name.as_str(),
+        }
     }
 }
 

--- a/src/models/manager.rs
+++ b/src/models/manager.rs
@@ -63,54 +63,33 @@ impl From<Manager> for DomainManager {
     }
 }
 
-impl<'a> From<&DomainNewManager<'a>> for NewManager<'a> {
-    fn from(manager: &DomainNewManager<'a>) -> Self {
+impl<'a> From<&'a DomainNewManager> for NewManager<'a> {
+    fn from(manager: &'a DomainNewManager) -> Self {
         Self {
             hub_id: manager.hub_id,
-            name: manager.name,
-            email: manager.email,
+            name: manager.name.as_str(),
+            email: manager.email.as_str(),
         }
     }
 }
 
-impl<'a> From<DomainNewManager<'a>> for NewManager<'a> {
-    fn from(manager: DomainNewManager<'a>) -> Self {
-        Self::from(&manager)
-    }
-}
-
-impl<'a> From<&DomainUpdateManager<'a>> for UpdateManager<'a> {
-    fn from(manager: &DomainUpdateManager<'a>) -> Self {
+impl<'a> From<&'a DomainUpdateManager<'a>> for UpdateManager<'a> {
+    fn from(manager: &'a DomainUpdateManager<'a>) -> Self {
         Self { name: manager.name }
     }
 }
 
-impl<'a> From<DomainUpdateManager<'a>> for UpdateManager<'a> {
-    fn from(manager: DomainUpdateManager<'a>) -> Self {
-        Self::from(&manager)
+impl<'a> From<&'a DomainNewManager> for UpdateManager<'a> {
+    fn from(manager: &'a DomainNewManager) -> Self {
+        Self {
+            name: manager.name.as_str(),
+        }
     }
 }
 
 impl<'a> From<&NewManager<'a>> for UpdateManager<'a> {
     fn from(manager: &NewManager<'a>) -> Self {
         Self { name: manager.name }
-    }
-}
-
-impl<'a> From<NewManager<'a>> for UpdateManager<'a> {
-    fn from(manager: NewManager<'a>) -> Self {
-        Self::from(&manager)
-    }
-}
-
-impl<'a> From<&DomainNewManager<'a>> for UpdateManager<'a> {
-    fn from(manager: &DomainNewManager<'a>) -> Self {
-        Self { name: manager.name }
-    }
-}
-impl<'a> From<DomainNewManager<'a>> for UpdateManager<'a> {
-    fn from(manager: DomainNewManager<'a>) -> Self {
-        Self::from(&manager)
     }
 }
 
@@ -138,11 +117,7 @@ mod tests {
 
     #[test]
     fn from_domain_newmanager() {
-        let domain = DomainNewManager {
-            hub_id: 1,
-            name: "Alice",
-            email: "a@b.c",
-        };
+        let domain = DomainNewManager::new(1, "Alice".to_string(), "a@b.c".to_string());
         let new: NewManager = (&domain).into();
         assert_eq!(new.hub_id, domain.hub_id);
         assert_eq!(new.name, domain.name);
@@ -151,7 +126,7 @@ mod tests {
         let update: UpdateManager = (&domain).into();
         assert_eq!(update.name, domain.name);
 
-        let update_from_new: UpdateManager = new.into();
+        let update_from_new: UpdateManager = (&new).into();
         assert_eq!(update_from_new.name, domain.name);
     }
 

--- a/src/repository/client.rs
+++ b/src/repository/client.rs
@@ -247,30 +247,6 @@ impl ClientReader for DieselRepository {
 }
 
 impl ClientWriter for DieselRepository {
-    // fn create_clients(&self, new_clients: &[NewClient]) -> RepositoryResult<usize> {
-    //     use crate::schema::clients;
-
-    //     let mut conn = self.conn()?;
-    //     let lower_emails: Vec<String> =
-    //         new_clients.iter().map(|c| c.email.to_lowercase()).collect();
-
-    //     let insertables: Vec<DbNewClient> = new_clients
-    //         .iter()
-    //         .zip(lower_emails.iter())
-    //         .map(|(client, email)| DbNewClient {
-    //             hub_id: client.hub_id,
-    //             name: client.name.as_str(),
-    //             email: email.as_str(),
-    //             phone: client.phone.as_str(),
-    //             address: client.address.as_str(),
-    //         })
-    //         .collect();
-    //     let affected = diesel::insert_into(clients::table)
-    //         .values(&insertables)
-    //         .execute(&mut conn)?;
-    //     Ok(affected)
-    // }
-
     fn create_clients(&self, new_clients: &[NewClient]) -> RepositoryResult<usize> {
         use crate::schema::{client_fields, clients};
 
@@ -280,9 +256,7 @@ impl ClientWriter for DieselRepository {
             let mut count_inserted: usize = 0;
 
             for new in new_clients {
-                let email = new.email.to_lowercase();
-                let mut db_new: DbNewClient = new.into();
-                db_new.email = email.as_str();
+                let db_new: DbNewClient = new.into();
 
                 let inserted = diesel::insert_into(clients::table)
                     .values(&db_new)
@@ -328,13 +302,7 @@ impl ClientWriter for DieselRepository {
         use crate::schema::{client_fields, clients};
 
         let mut conn = self.conn()?;
-        let email = updates.email.to_lowercase();
-        let db_updates = DbUpdateClient {
-            name: updates.name,
-            email: email.as_str(),
-            phone: updates.phone,
-            address: updates.address,
-        };
+        let db_updates: DbUpdateClient = updates.into();
 
         let mut updated: Client = diesel::update(clients::table.find(client_id))
             .set(&db_updates)

--- a/src/repository/manager.rs
+++ b/src/repository/manager.rs
@@ -22,10 +22,7 @@ impl ManagerWriter for DieselRepository {
 
         let mut conn = self.conn()?;
 
-        let email = new_manager.email.to_lowercase();
-
-        let mut db_new_manager: DbNewManager = new_manager.into();
-        db_new_manager.email = email.as_str();
+        let db_new_manager: DbNewManager = new_manager.into();
 
         let db_update_manager: DbUpdateManager = new_manager.into();
 

--- a/src/routes/managers.rs
+++ b/src/routes/managers.rs
@@ -60,11 +60,7 @@ pub async fn add_manager(
         return redirect("/managers");
     }
 
-    let new_manager = NewManager {
-        hub_id: user.hub_id,
-        name: &form.name,
-        email: &form.email,
-    };
+    let new_manager = NewManager::new(user.hub_id, form.name.clone(), form.email.clone());
 
     match repo.create_or_update_manager(&new_manager) {
         Ok(_) => {

--- a/tests/repository.rs
+++ b/tests/repository.rs
@@ -15,22 +15,22 @@ mod common;
 fn test_client_repository_crud() {
     let test_db = common::TestDb::new("test_client_repository_crud.db");
     let client_repo = DieselRepository::new(test_db.pool());
-    let c1 = NewClient {
-        hub_id: 1,
-        name: "Alice".into(),
-        email: "alice@example.com".into(),
-        phone: "111".into(),
-        address: "Addr1".into(),
-        fields: None,
-    };
-    let c2 = NewClient {
-        hub_id: 1,
-        name: "Bob".into(),
-        email: "bob@example.com".into(),
-        phone: "222".into(),
-        address: "Addr2".into(),
-        fields: None,
-    };
+    let c1 = NewClient::new(
+        1,
+        "Alice".into(),
+        "alice@example.com".into(),
+        "111".into(),
+        "Addr1".into(),
+        None,
+    );
+    let c2 = NewClient::new(
+        1,
+        "Bob".into(),
+        "bob@example.com".into(),
+        "222".into(),
+        "Addr2".into(),
+        None,
+    );
 
     assert_eq!(
         client_repo
@@ -55,13 +55,13 @@ fn test_client_repository_crud() {
     alice = client_repo
         .update_client(
             alice.id,
-            &UpdateClient {
-                name: &alice.name,
-                email: &alice.email,
-                phone: &alice.phone,
-                address: &alice.address,
-                fields: HashMap::from([("vip", "true")]),
-            },
+            &UpdateClient::new(
+                alice.name.clone(),
+                alice.email.clone(),
+                alice.phone.clone(),
+                alice.address.clone(),
+                HashMap::from([("vip".to_string(), "true".to_string())]),
+            ),
         )
         .unwrap();
     assert_eq!(
@@ -72,13 +72,13 @@ fn test_client_repository_crud() {
     bob = client_repo
         .update_client(
             bob.id,
-            &UpdateClient {
-                name: "Bobby",
-                email: &bob.email,
-                phone: &bob.phone,
-                address: &bob.address,
-                fields: HashMap::new(),
-            },
+            &UpdateClient::new(
+                "Bobby".to_string(),
+                bob.email.clone(),
+                bob.phone.clone(),
+                bob.address.clone(),
+                HashMap::new(),
+            ),
         )
         .unwrap();
     assert_eq!(bob.name, "Bobby");
@@ -97,14 +97,14 @@ fn test_client_event_repository_crud() {
     let client_repo = DieselRepository::new(test_db.pool());
     let manager_repo = DieselRepository::new(test_db.pool());
     let client = {
-        let new_client = NewClient {
-            hub_id: 1,
-            name: "Alice".into(),
-            email: "alice@example.com".into(),
-            phone: "111".into(),
-            address: "Addr1".into(),
-            fields: None,
-        };
+        let new_client = NewClient::new(
+            1,
+            "Alice".into(),
+            "alice@example.com".into(),
+            "111".into(),
+            "Addr1".into(),
+            None,
+        );
         client_repo.create_clients(&[new_client]).unwrap();
         client_repo
             .list_clients(ClientListQuery::new(1))
@@ -113,11 +113,11 @@ fn test_client_event_repository_crud() {
             .remove(0)
     };
     let manager = manager_repo
-        .create_or_update_manager(&NewManager {
-            hub_id: 1,
-            name: "Manager",
-            email: "m@example.com",
-        })
+        .create_or_update_manager(&NewManager::new(
+            1,
+            "Manager".to_string(),
+            "m@example.com".to_string(),
+        ))
         .unwrap();
 
     let client_event_repo = DieselRepository::new(test_db.pool());
@@ -166,22 +166,22 @@ fn test_manager_repository_crud() {
 
     // create clients
     let clients = vec![
-        NewClient {
-            hub_id: 1,
-            name: "Alice".into(),
-            email: "alice@example.com".into(),
-            phone: "111".into(),
-            address: "Addr1".into(),
-            fields: None,
-        },
-        NewClient {
-            hub_id: 1,
-            name: "Bob".into(),
-            email: "bob@example.com".into(),
-            phone: "222".into(),
-            address: "Addr2".into(),
-            fields: None,
-        },
+        NewClient::new(
+            1,
+            "Alice".into(),
+            "alice@example.com".into(),
+            "111".into(),
+            "Addr1".into(),
+            None,
+        ),
+        NewClient::new(
+            1,
+            "Bob".into(),
+            "bob@example.com".into(),
+            "222".into(),
+            "Addr2".into(),
+            None,
+        ),
     ];
     client_repo.create_clients(&clients).unwrap();
     let (_, stored_clients) = client_repo.list_clients(ClientListQuery::new(1)).unwrap();
@@ -189,20 +189,20 @@ fn test_manager_repository_crud() {
 
     // create or update manager
     let manager = manager_repo
-        .create_or_update_manager(&NewManager {
-            hub_id: 1,
-            name: "Manager",
-            email: "m@example.com",
-        })
+        .create_or_update_manager(&NewManager::new(
+            1,
+            "Manager".to_string(),
+            "m@example.com".to_string(),
+        ))
         .unwrap();
     assert!(manager.id > 0);
 
     let updated = manager_repo
-        .create_or_update_manager(&NewManager {
-            hub_id: 1,
-            name: "Updated",
-            email: "m@example.com",
-        })
+        .create_or_update_manager(&NewManager::new(
+            1,
+            "Updated".to_string(),
+            "m@example.com".to_string(),
+        ))
         .unwrap();
     assert_eq!(updated.id, manager.id);
     assert_eq!(updated.name, "Updated");


### PR DESCRIPTION
## Summary
- add constructors for domain new client, update client and new manager that lowercase emails
- use new constructors across forms, routes and repos
- drop ad-hoc email.lowercase() calls

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b31679d66c832aa27a1f32eb229ef2