### PR TITLE
Deduplicate client events on creation

### DIFF
--- a/src/repository/client_event.rs
+++ b/src/repository/client_event.rs
@@ -86,6 +86,18 @@ impl ClientEventWriter for DieselRepository {
 
         let new_client_event: DbNewClientEvent = client_event.into();
 
+        if let Some(existing_event) = client_events::table
+            .filter(client_events::client_id.eq(new_client_event.client_id))
+            .filter(client_events::manager_id.eq(new_client_event.manager_id))
+            .filter(client_events::event_type.eq(&new_client_event.event_type))
+            .filter(client_events::event_data.eq(&new_client_event.event_data))
+            .order(client_events::created_at.desc())
+            .first::<DbClientEvent>(&mut conn)
+            .optional()?
+        {
+            return Ok(existing_event.into());
+        }
+
         let client_event = diesel::insert_into(client_events::table)
             .values(&new_client_event)
             .get_result::<DbClientEvent>(&mut conn)?;

--- a/tests/repository.rs
+++ b/tests/repository.rs
@@ -127,6 +127,21 @@ fn test_client_event_repository_crud() {
     let created = client_event_repo.create_client_event(&new_event).unwrap();
     assert_eq!(created.event_type, ClientEventType::Comment);
 
+    let duplicate_attempt = NewClientEvent {
+        created_at: Utc::now().naive_utc(),
+        ..new_event.clone()
+    };
+    let duplicate = client_event_repo
+        .create_client_event(&duplicate_attempt)
+        .unwrap();
+    assert_eq!(duplicate.id, created.id);
+
+    let (total_after_duplicate, events_after_duplicate) = client_event_repo
+        .list_client_events(ClientEventListQuery::new(client.id))
+        .unwrap();
+    assert_eq!(total_after_duplicate, 1);
+    assert_eq!(events_after_duplicate.len(), 1);
+
     let _ = client_event_repo
         .create_client_event(&NewClientEvent {
             client_id: client.id,


### PR DESCRIPTION
## Summary
- avoid inserting duplicate client events when a record already exists with the same client, manager, type, and data
- extend repository tests to verify duplicate event requests reuse the existing database row

## Testing
- cargo fmt --all
- cargo clippy --all-features --tests -- -Dwarnings
- cargo build --all-features --verbose
- cargo test --all-features --verbose

------
https://chatgpt.com/codex/tasks/task_e_68ca4212cb8c832a935de32c1fcaefd3