### PR TITLE
Limit client event deduplication to event worker

### DIFF
--- a/src/repository/client_event.rs
+++ b/src/repository/client_event.rs
@@ -86,18 +86,6 @@ impl ClientEventWriter for DieselRepository {
 
         let new_client_event: DbNewClientEvent = client_event.into();
 
-        if let Some(existing_event) = client_events::table
-            .filter(client_events::client_id.eq(new_client_event.client_id))
-            .filter(client_events::manager_id.eq(new_client_event.manager_id))
-            .filter(client_events::event_type.eq(&new_client_event.event_type))
-            .filter(client_events::event_data.eq(&new_client_event.event_data))
-            .order(client_events::created_at.desc())
-            .first::<DbClientEvent>(&mut conn)
-            .optional()?
-        {
-            return Ok(existing_event.into());
-        }
-
         let client_event = diesel::insert_into(client_events::table)
             .values(&new_client_event)
             .get_result::<DbClientEvent>(&mut conn)?;

--- a/tests/repository.rs
+++ b/tests/repository.rs
@@ -134,13 +134,13 @@ fn test_client_event_repository_crud() {
     let duplicate = client_event_repo
         .create_client_event(&duplicate_attempt)
         .unwrap();
-    assert_eq!(duplicate.id, created.id);
+    assert_ne!(duplicate.id, created.id);
 
     let (total_after_duplicate, events_after_duplicate) = client_event_repo
         .list_client_events(ClientEventListQuery::new(client.id))
         .unwrap();
-    assert_eq!(total_after_duplicate, 1);
-    assert_eq!(events_after_duplicate.len(), 1);
+    assert_eq!(total_after_duplicate, 2);
+    assert_eq!(events_after_duplicate.len(), 2);
 
     let _ = client_event_repo
         .create_client_event(&NewClientEvent {
@@ -155,8 +155,8 @@ fn test_client_event_repository_crud() {
     let (total, events) = client_event_repo
         .list_client_events(ClientEventListQuery::new(client.id))
         .unwrap();
-    assert_eq!(total, 2);
-    assert_eq!(events.len(), 2);
+    assert_eq!(total, 3);
+    assert_eq!(events.len(), 3);
     assert_eq!(events[0].1.id, manager.id);
 
     let (total_comment, comments) = client_event_repo
@@ -164,8 +164,12 @@ fn test_client_event_repository_crud() {
             ClientEventListQuery::new(client.id).event_type(ClientEventType::Comment),
         )
         .unwrap();
-    assert_eq!(total_comment, 1);
-    assert_eq!(comments[0].0.event_type, ClientEventType::Comment);
+    assert_eq!(total_comment, 2);
+    assert!(
+        comments
+            .iter()
+            .all(|(event, _)| event.event_type == ClientEventType::Comment)
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- move client event duplicate detection into the check_events worker using the reader API
- remove the repository-level guard that prevented inserting duplicate events
- update repository tests to expect duplicate rows and verify comment event counts

## Testing
- cargo fmt
- cargo test --all-features
- cargo clippy --all-features --tests -- -Dwarnings

------
https://chatgpt.com/codex/tasks/task_e_68ca96db61ec832a83d4809e710ec84d