### PR TITLE
[codex] Expand CRM e2e coverage and lock /api/v1/clients admin access

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ app.db*
 tarpaulin-report*
 frontend/node_modules/
 assets/dist/
+.codex

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,7 +78,7 @@ dependencies = [
  "foldhash 0.1.5",
  "futures-core",
  "h2",
- "http",
+ "http 0.2.12",
  "httparse",
  "httpdate",
  "itoa",
@@ -168,7 +168,7 @@ checksum = "14f8c75c51892f18d9c46150c5ac7beb81c95f78c8b83a634d49f4ca32551fe7"
 dependencies = [
  "bytestring",
  "cfg-if",
- "http",
+ "http 0.2.12",
  "regex",
  "regex-lite",
  "serde",
@@ -257,7 +257,7 @@ dependencies = [
  "bytes",
  "bytestring",
  "cfg-if",
- "cookie",
+ "cookie 0.16.2",
  "derive_more 2.1.1",
  "encoding_rs",
  "foldhash 0.1.5",
@@ -467,6 +467,12 @@ checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
 dependencies = [
  "critical-section",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
@@ -763,6 +769,35 @@ dependencies = [
  "subtle",
  "time",
  "version_check",
+]
+
+[[package]]
+name = "cookie"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
+dependencies = [
+ "cookie 0.18.1",
+ "document-features",
+ "idna",
+ "log",
+ "publicsuffix",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
 ]
 
 [[package]]
@@ -1127,6 +1162,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
 name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1317,6 +1361,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1450,7 +1503,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.12",
  "indexmap",
  "slab",
  "tokio",
@@ -1555,6 +1608,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http 1.4.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.4.0",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "http-range"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1579,6 +1665,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6cb51c9a029ddc91b07a787f1d86b53ccfa49b0e86688c946ebe8d3555685dd7"
 dependencies = [
  "libm",
+]
+
+[[package]]
+name = "hyper"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http 1.4.0",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "pin-utils",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.4.0",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2 0.6.3",
+ "tokio",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1763,6 +1893,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "iri-string"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8e7418f59cc01c88316161279a7f665217ae316b388e58a0d10e29f54f1e5eb"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1902,6 +2048,12 @@ name = "litemap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "local-channel"
@@ -2331,6 +2483,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2474,6 +2632,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "psl-types"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
+
+[[package]]
+name = "publicsuffix"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42ea446cab60335f76979ec15e12619a2165b5ae2c12166bef27d283a9fadf"
+dependencies = [
+ "idna",
+ "psl-types",
+]
+
+[[package]]
 name = "pushkind-common"
 version = "0.1.0"
 source = "git+https://github.com/pushkindt/pushkind-common.git?branch=main#a5a1236f66e7d83d8711afaee9424509df41c15c"
@@ -2523,6 +2697,7 @@ dependencies = [
  "pushkind-sms",
  "pushkind-todo",
  "rand 0.10.0",
+ "reqwest",
  "serde",
  "serde_html_form",
  "serde_json",
@@ -2775,6 +2950,41 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "reqwest"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "cookie 0.18.1",
+ "cookie_store",
+ "futures-core",
+ "futures-util",
+ "http 1.4.0",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime_guess",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
 
 [[package]]
 name = "rsqlite-vfs"
@@ -3155,6 +3365,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3412,6 +3631,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags 2.11.0",
+ "bytes",
+ "futures-util",
+ "http 1.4.0",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
 name = "tracing"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3442,6 +3706,12 @@ checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
 ]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
@@ -3608,6 +3878,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3642,6 +3921,20 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -3708,6 +4001,16 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,4 +105,9 @@ required-features = ["server"]
 
 [dev-dependencies]
 diesel_migrations = "2.3.1"
+reqwest = { version = "0.13.2", default-features = false, features = [
+    "cookies",
+    "json",
+    "multipart",
+] }
 tempfile = "3.27.0"

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,15 @@
+.PHONY: check coverage
+
 check:
-	cargo fmt --all
+	@printf '%s\n' '==> cargo fmt --check'
+	cargo fmt --all -- --check
+	@printf '%s\n' '==> cargo clippy'
 	cargo clippy --all-features --all-targets --tests -- -Dwarnings
+	@printf '%s\n' '==> cargo test'
 	cargo test --all-features --all-targets
+	@printf '%s\n' '==> cargo test --ignored e2e'
+	cargo test --all-features --test e2e -- --ignored
 
 coverage:
 	cargo tarpaulin --all-features --all-targets --out Html
+	wslview tarpaulin-report.html

--- a/plans/api-v1-clients-admin-access.md
+++ b/plans/api-v1-clients-admin-access.md
@@ -1,0 +1,17 @@
+# Plan: API V1 Clients Admin Access
+
+## References
+- Feature spec:
+  [../specs/features/api-v1-clients-admin-access.md](../specs/features/api-v1-clients-admin-access.md)
+- Source of truth:
+  [../SPEC.md](../SPEC.md)
+
+## Objective
+Close the remaining contract gap for `GET /api/v1/clients` by verifying
+`crm_admin`-only access end to end and aligning the route documentation with the
+actual authorization behavior.
+
+## Work Items
+1. Update the route comment for `GET /api/v1/clients`.
+2. Extend the admin-only e2e story with a `GET /api/v1/clients` assertion.
+3. Run the targeted ignored e2e test.

--- a/plans/e2e-user-story-coverage.md
+++ b/plans/e2e-user-story-coverage.md
@@ -1,0 +1,27 @@
+# Plan: E2E User Story Coverage Expansion
+
+## References
+- Feature spec:
+  [../specs/features/e2e-user-story-coverage.md](../specs/features/e2e-user-story-coverage.md)
+- Source of truth:
+  [../SPEC.md](../SPEC.md)
+
+## Objective
+Close the most important CRM user-story coverage gaps in `tests/e2e.rs` while
+keeping the suite aligned with the existing end-to-end harness and the route and
+worker contracts defined in `SPEC.md`.
+
+## Work Items
+1. Add route-driven coverage for cross-hub isolation.
+2. Add route-driven coverage for admin-only APIs and mutations that are still
+   uncovered.
+3. Add route-driven coverage for manager assignment replacement and missing
+   manager failures.
+4. Add route-driven coverage for exact `public_id` filtering and pagination.
+5. Add route-driven coverage for client-detail manager aggregation,
+   sanitization, and newest-first event ordering.
+6. Reuse the real `check_events` processing helpers in `tests/e2e.rs` to cover
+   reply, unsubscribe, and task-event ingestion with the Diesel repository.
+
+## Verification
+- Run `cargo test --test e2e -- --ignored`.

--- a/plans/make-check-reporting.md
+++ b/plans/make-check-reporting.md
@@ -1,0 +1,16 @@
+# Plan: Make Check Reporting
+
+## References
+- Feature spec:
+  [../specs/features/make-check-reporting.md](../specs/features/make-check-reporting.md)
+
+## Objective
+Make the repository `check` target behave like a validation command: report
+issues and fail fast, rather than mutating the working tree.
+
+## Work Items
+1. Update `Makefile` to run `cargo fmt` in `--check` mode.
+2. Add short progress labels for each step so failures are attributable at a
+   glance.
+3. Re-run `make check` to verify the target still succeeds when the tree is
+   clean.

--- a/specs/features/api-v1-clients-admin-access.md
+++ b/specs/features/api-v1-clients-admin-access.md
@@ -1,0 +1,26 @@
+# API V1 Clients Admin Access
+
+## Status
+Stable
+
+## Date
+2026-03-28
+
+## Summary
+Ensure `GET /api/v1/clients` explicitly preserves the documented behavior that
+both `crm` and `crm_admin` users may access the endpoint, and cover that
+contract in the end-to-end suite.
+
+## Goals
+- Verify `crm_admin`-only users can fetch `GET /api/v1/clients`.
+- Keep the HTTP contract documentation aligned with the implementation.
+
+## Non-Goals
+- Broadening access beyond the roles already documented in `SPEC.md`.
+- Changing the endpoint payload shape.
+
+## Acceptance Criteria
+- `tests/e2e.rs` asserts that a `crm_admin`-only user receives `200 OK` from
+  `GET /api/v1/clients`.
+- The route documentation for `GET /api/v1/clients` no longer implies that the
+  `crm` role is required when `crm_admin` is also valid.

--- a/specs/features/e2e-user-story-coverage.md
+++ b/specs/features/e2e-user-story-coverage.md
@@ -1,0 +1,43 @@
+# E2E User Story Coverage Expansion
+
+## Status
+Stable
+
+## Date
+2026-03-28
+
+## Summary
+Expand `tests/e2e.rs` so the CRM end-to-end suite covers the remaining
+high-value user stories and edge cases defined in `SPEC.md`, not only the
+existing happy-path role stories.
+
+## Goals
+- Cover cross-hub isolation for HTML routes, JSON APIs, and destructive admin
+  actions.
+- Cover admin-only management APIs and mutations that were not exercised by the
+  existing suite.
+- Cover manager assignment replacement semantics and missing-manager failures.
+- Cover exact `public_id` filtering and pagination through the public CRM APIs.
+- Cover client-detail expectations for assigned managers, sanitized user
+  content, and newest-first event ordering.
+- Cover worker-driven client event ingestion for replies, unsubscribes, and
+  task notifications.
+
+## Non-Goals
+- Replacing unit tests for forms, services, or repository builders.
+- End-to-end verification of external mailer delivery itself.
+- Browser-level assertions about Bootstrap widgets or visual appearance.
+
+## Acceptance Criteria
+- `tests/e2e.rs` contains route-driven scenarios for:
+  - cross-hub isolation
+  - admin-only management endpoints
+  - manager assignment replacement and not-found handling
+  - `public_id` filtering and pagination
+  - client-detail sanitization and event ordering
+- `tests/e2e.rs` contains worker-ingestion scenarios for:
+  - reply events
+  - unsubscribe events
+  - task events
+- New assertions use the real HTTP surface or the real Diesel repository used by
+  the existing end-to-end harness.

--- a/specs/features/make-check-reporting.md
+++ b/specs/features/make-check-reporting.md
@@ -1,0 +1,25 @@
+# Make Check Reporting
+
+## Status
+Stable
+
+## Date
+2026-03-28
+
+## Summary
+Adjust the repository `make check` workflow so it reports validation issues
+instead of silently fixing them during the check run.
+
+## Goals
+- Ensure `make check` fails when formatting is out of date.
+- Keep the existing lint and test coverage steps intact.
+- Make the output identify which validation phase is currently running.
+
+## Non-Goals
+- Changing the underlying Rust validation commands beyond check-mode behavior.
+- Introducing new CI stages or architecture changes.
+
+## Acceptance Criteria
+- `make check` uses `cargo fmt --all -- --check`.
+- `make check` still runs clippy, the full test suite, and ignored e2e tests.
+- The command output clearly labels each validation phase.

--- a/src/bin/check_events.rs
+++ b/src/bin/check_events.rs
@@ -27,7 +27,7 @@ use pushkind_crm::{
     models::zmq::ZmqClientMessage,
 };
 
-fn process_email_event<R>(msg: ZMQSendEmailMessage, repo: R) -> RepositoryResult<()>
+pub(crate) fn process_email_event<R>(msg: ZMQSendEmailMessage, repo: R) -> RepositoryResult<()>
 where
     R: ClientEventWriter + ManagerWriter + ClientReader + ClientEventReader,
 {
@@ -83,7 +83,7 @@ where
     Ok(())
 }
 
-fn process_task_message<R>(task: ZmqTask, repo: R) -> RepositoryResult<()>
+pub(crate) fn process_task_message<R>(task: ZmqTask, repo: R) -> RepositoryResult<()>
 where
     R: ClientEventWriter + ClientEventReader + ClientReader + ManagerWriter,
 {
@@ -172,7 +172,7 @@ where
     Ok(())
 }
 
-fn process_reply_message<R>(reply: ZMQReplyMessage, repo: R) -> RepositoryResult<()>
+pub(crate) fn process_reply_message<R>(reply: ZMQReplyMessage, repo: R) -> RepositoryResult<()>
 where
     R: ClientEventWriter + ManagerWriter + ClientReader + ClientEventReader,
 {
@@ -214,7 +214,10 @@ where
     Ok(())
 }
 
-fn process_unsubscribe_message<R>(message: ZMQUnsubscribeMessage, repo: R) -> RepositoryResult<()>
+pub(crate) fn process_unsubscribe_message<R>(
+    message: ZMQUnsubscribeMessage,
+    repo: R,
+) -> RepositoryResult<()>
 where
     R: ClientEventWriter + ManagerWriter + ClientReader + ClientEventReader,
 {

--- a/src/routes/api.rs
+++ b/src/routes/api.rs
@@ -132,7 +132,8 @@ pub async fn api_v1_no_access(
 #[get("/v1/clients")]
 /// Return a JSON list of clients with optional search and pagination.
 ///
-/// Users without the `crm` role receive a `401 Unauthorized` response.
+/// Users without either the `crm` or `crm_admin` role receive a
+/// `401 Unauthorized` response.
 pub async fn api_v1_clients(
     params: web::Query<ClientsQuery>,
     user: AuthenticatedUser,

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,15 +1,53 @@
+#![allow(dead_code)]
+
 //! Helpers for integration tests.
 
+use std::net::TcpListener;
+use std::sync::Arc;
+use std::time::Duration;
+
+use actix_cors::Cors;
+use actix_identity::{Identity, IdentityMiddleware};
+use actix_session::{SessionMiddleware, storage::CookieSessionStore};
+use actix_web::cookie::Key;
+use actix_web::rt::time::sleep;
+use actix_web::{
+    App, HttpMessage, HttpRequest, HttpResponse, HttpServer, Responder, middleware, post, web,
+};
 use diesel_migrations::{EmbeddedMigrations, MigrationHarness, embed_migrations};
 use pushkind_common::db::{DbPool, establish_connection_pool};
+use pushkind_common::domain::auth::AuthenticatedUser;
+use pushkind_common::middleware::RedirectUnauthorized;
+use pushkind_common::models::config::CommonServerConfig;
+use pushkind_common::routes::logout;
+use pushkind_common::zmq::{ZmqSender, ZmqSenderOptions};
+use reqwest::{Client, StatusCode, redirect::Policy};
 use tempfile::NamedTempFile;
 
+use pushkind_crm::models::config::AppConfig;
+use pushkind_crm::repository::DieselRepository;
+use pushkind_crm::routes::api::{
+    api_v1_client_details, api_v1_client_directory, api_v1_clients, api_v1_iam,
+    api_v1_important_fields, api_v1_manager_modal, api_v1_managers, api_v1_no_access,
+};
+use pushkind_crm::routes::aux::not_assigned;
+use pushkind_crm::routes::client::{attachment_client, comment_client, save_client, show_client};
+use pushkind_crm::routes::main::{add_client, clients_upload, show_index};
+use pushkind_crm::routes::managers::{add_manager, assign_manager, managers};
+use pushkind_crm::routes::settings::{cleanup_clients, save_important_fields, show_settings};
+
 pub const MIGRATIONS: EmbeddedMigrations = embed_migrations!(); // assumes migrations/ exists
+pub const HUB_ID: i32 = 7;
 
 /// Temporary database used in integration tests.
 pub struct TestDb {
     _tempfile: NamedTempFile,
     pool: DbPool,
+}
+
+pub struct TestApp {
+    test_db: TestDb,
+    address: String,
 }
 
 impl TestDb {
@@ -31,4 +69,209 @@ impl TestDb {
     pub fn pool(&self) -> DbPool {
         self.pool.clone()
     }
+
+    pub fn get_db_path(&self) -> String {
+        self._tempfile.path().to_str().unwrap().to_string()
+    }
+}
+
+impl TestApp {
+    pub fn address(&self) -> &str {
+        &self.address
+    }
+
+    pub fn db_pool(&self) -> DbPool {
+        self.test_db.pool()
+    }
+
+    pub fn repo(&self) -> DieselRepository {
+        DieselRepository::new(self.db_pool())
+    }
+}
+
+#[derive(serde::Deserialize)]
+struct LoginRequest {
+    hub_id: i32,
+    email: String,
+    name: String,
+    roles: Vec<String>,
+}
+
+#[post("/test/login")]
+async fn test_login(
+    request: HttpRequest,
+    payload: web::Json<LoginRequest>,
+    common_config: web::Data<CommonServerConfig>,
+) -> impl Responder {
+    let mut user = AuthenticatedUser {
+        sub: payload.email.clone(),
+        email: payload.email.clone(),
+        hub_id: payload.hub_id,
+        name: payload.name.clone(),
+        roles: payload.roles.clone(),
+        exp: 0,
+    };
+    user.set_expiration(7);
+
+    let token = user
+        .to_jwt(&common_config.secret)
+        .expect("JWT generation should succeed for test users.");
+    Identity::login(&request.extensions(), token).expect("Test login should persist identity.");
+
+    HttpResponse::Ok().finish()
+}
+
+async fn wait_until_server_is_ready(address: &str) {
+    let client = Client::builder()
+        .redirect(Policy::none())
+        .timeout(Duration::from_millis(100))
+        .build()
+        .expect("Failed to create the test HTTP client.");
+    let url = format!("{address}/");
+
+    for _ in 0..20 {
+        match client.get(&url).send().await {
+            Ok(response)
+                if response.status() == StatusCode::SEE_OTHER
+                    || response.status() == StatusCode::OK =>
+            {
+                return;
+            }
+            Ok(_) | Err(_) => sleep(Duration::from_millis(25)).await,
+        }
+    }
+
+    panic!("Test server did not become ready at {url}");
+}
+
+pub async fn spawn_app() -> TestApp {
+    let test_db = TestDb::new();
+    let listener = TcpListener::bind("127.0.0.1:0").expect("Failed to bind a random local port.");
+    let port = listener
+        .local_addr()
+        .expect("Failed to read the local socket address.")
+        .port();
+
+    let app_config = AppConfig {
+        domain: "localhost".to_string(),
+        database_url: test_db.get_db_path(),
+        zmq_emailer_pub: "tcp://127.0.0.1:35557".to_string(),
+        zmq_emailer_sub: "tcp://127.0.0.1:35558".to_string(),
+        zmq_sms_pub: "tcp://127.0.0.1:35561".to_string(),
+        zmq_clients_sub: "tcp://127.0.0.1:35566".to_string(),
+        zmq_replier_sub: "tcp://127.0.0.1:35560".to_string(),
+        zmq_tasks_sub: "tcp://127.0.0.1:35564".to_string(),
+        sms_sender: "crm-test".to_string(),
+        secret: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef".to_string(),
+        auth_service_url: "https://users.pushkind.test/auth/signin".to_string(),
+        todo_service_url: "https://todo.pushkind.test".to_string(),
+        files_service_url: "https://files.pushkind.test".to_string(),
+    };
+    let common_config = CommonServerConfig {
+        auth_service_url: app_config.auth_service_url.clone(),
+        secret: app_config.secret.clone(),
+    };
+    let secret_key = Key::from(app_config.secret.as_bytes());
+    let repo = DieselRepository::new(test_db.pool());
+    let zmq_sender = Arc::new(
+        ZmqSender::start(ZmqSenderOptions::pub_default("tcp://127.0.0.1:35559"))
+            .expect("Failed to start test ZMQ sender."),
+    );
+
+    let server = HttpServer::new(move || {
+        App::new()
+            .wrap(Cors::permissive())
+            .wrap(IdentityMiddleware::default())
+            .wrap(
+                SessionMiddleware::builder(CookieSessionStore::default(), secret_key.clone())
+                    .cookie_secure(false)
+                    .build(),
+            )
+            .wrap(middleware::Compress::default())
+            .wrap(middleware::Logger::default())
+            .service(actix_files::Files::new("/assets", "./assets"))
+            .service(test_login)
+            .service(not_assigned)
+            .service(
+                web::scope("/api")
+                    .service(api_v1_iam)
+                    .service(api_v1_clients)
+                    .service(api_v1_client_directory)
+                    .service(api_v1_client_details)
+                    .service(api_v1_managers)
+                    .service(api_v1_manager_modal)
+                    .service(api_v1_no_access)
+                    .service(api_v1_important_fields),
+            )
+            .service(
+                web::scope("")
+                    .wrap(RedirectUnauthorized)
+                    .service(show_index)
+                    .service(add_client)
+                    .service(clients_upload)
+                    .service(show_client)
+                    .service(save_client)
+                    .service(comment_client)
+                    .service(attachment_client)
+                    .service(show_settings)
+                    .service(save_important_fields)
+                    .service(cleanup_clients)
+                    .service(managers)
+                    .service(add_manager)
+                    .service(assign_manager)
+                    .service(logout),
+            )
+            .app_data(web::Data::new(repo.clone()))
+            .app_data(web::Data::new(common_config.clone()))
+            .app_data(web::Data::new(zmq_sender.clone()))
+            .app_data(web::Data::new(app_config.clone()))
+    })
+    .listen(listener)
+    .expect("Failed to listen with the test server.")
+    .run();
+
+    actix_web::rt::spawn(server);
+    let address = format!("http://127.0.0.1:{port}");
+
+    wait_until_server_is_ready(&address).await;
+
+    TestApp { test_db, address }
+}
+
+pub fn build_reqwest_client() -> Client {
+    Client::builder()
+        .cookie_store(true)
+        .build()
+        .expect("Can't create a request client")
+}
+
+pub fn build_no_redirect_client() -> Client {
+    Client::builder()
+        .cookie_store(true)
+        .redirect(Policy::none())
+        .build()
+        .expect("Can't create a request client")
+}
+
+pub async fn login_as(
+    client: &Client,
+    address: &str,
+    email: &str,
+    name: &str,
+    hub_id: i32,
+    roles: &[&str],
+) {
+    let response = client
+        .post(format!("{address}/test/login"))
+        .json(&serde_json::json!({
+            "hub_id": hub_id,
+            "email": email,
+            "name": name,
+            "roles": roles,
+        }))
+        .send()
+        .await
+        .expect("Failed to submit test login.");
+
+    assert_eq!(response.status(), StatusCode::OK);
 }

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -1,0 +1,1736 @@
+use std::{collections::BTreeMap, time::Duration};
+
+use actix_web::rt::time::sleep;
+use chrono::Utc;
+use pushkind_common::pagination::DEFAULT_ITEMS_PER_PAGE;
+use pushkind_emailer::models::zmq::{ZMQReplyMessage, ZMQUnsubscribeMessage};
+use pushkind_todo::{
+    domain::task::{TaskPriority, TaskStatus},
+    dto::zmq::{ZmqTask, ZmqTaskAssignee, ZmqTaskAuthor, ZmqTaskClient},
+};
+use reqwest::{StatusCode, header, multipart};
+use serde_json::Value;
+
+#[allow(dead_code)]
+#[path = "../src/bin/check_events.rs"]
+mod check_events_bin;
+mod common;
+
+use pushkind_crm::{
+    domain::{
+        client::NewClient,
+        client_event::ClientEventType,
+        manager::NewManager,
+        types::{ClientEmail, HubId, ManagerEmail},
+    },
+    repository::{
+        ClientEventListQuery, ClientEventReader, ClientListQuery, ClientReader, ClientWriter,
+        DieselRepository, ImportantFieldReader, ManagerReader, ManagerWriter,
+    },
+};
+
+const OTHER_HUB_ID: i32 = 8;
+
+async fn response_json(response: reqwest::Response) -> Value {
+    let body = response
+        .text()
+        .await
+        .expect("Response body should be readable.");
+    serde_json::from_str(&body).expect("Response body should be valid JSON.")
+}
+
+fn repo(app: &common::TestApp) -> DieselRepository {
+    app.repo()
+}
+
+fn hub_id() -> HubId {
+    HubId::new(common::HUB_ID).expect("valid hub id")
+}
+
+fn other_hub_id() -> HubId {
+    HubId::new(OTHER_HUB_ID).expect("valid other hub id")
+}
+
+fn form_body(fields: Vec<(impl Into<String>, impl Into<String>)>) -> String {
+    let fields = fields
+        .into_iter()
+        .map(|(key, value)| (key.into(), value.into()))
+        .collect::<Vec<(String, String)>>();
+    serde_html_form::to_string(&fields).expect("Form body should serialize.")
+}
+
+#[ignore = "local-only end-to-end test"]
+#[actix_web::test]
+async fn test_crm_logged_out_user_is_redirected_to_auth() {
+    let app = common::spawn_app().await;
+    let client = common::build_no_redirect_client();
+
+    let response = client
+        .get(format!("{}/", app.address()))
+        .send()
+        .await
+        .expect("Failed to request CRM index.");
+
+    assert_eq!(response.status(), StatusCode::SEE_OTHER);
+    let location = response
+        .headers()
+        .get(header::LOCATION)
+        .and_then(|value| value.to_str().ok())
+        .expect("Redirect location should be present.");
+    assert!(location.starts_with("https://users.pushkind.test/auth/signin?next="));
+
+    let api_response = client
+        .get(format!("{}/api/v1/client-directory", app.address()))
+        .send()
+        .await
+        .expect("Failed to request CRM directory API.");
+
+    assert_eq!(api_response.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[ignore = "local-only end-to-end test"]
+#[actix_web::test]
+async fn test_crm_admin_full_management_story() {
+    let app = common::spawn_app().await;
+    let client = common::build_reqwest_client();
+    let repo = repo(&app);
+
+    common::login_as(
+        &client,
+        app.address(),
+        "admin@example.com",
+        "Admin User",
+        common::HUB_ID,
+        &["crm", "crm_admin"],
+    )
+    .await;
+
+    let index_response = client
+        .get(format!("{}/", app.address()))
+        .send()
+        .await
+        .expect("Failed to request CRM index.");
+
+    assert_eq!(index_response.status(), StatusCode::OK);
+    let index_html = index_response
+        .text()
+        .await
+        .expect("CRM index should be readable.");
+    assert!(index_html.contains("<title>CRM</title>"));
+
+    let iam_response = client
+        .get(format!("{}/api/v1/iam", app.address()))
+        .send()
+        .await
+        .expect("Failed to request IAM payload.");
+
+    assert_eq!(iam_response.status(), StatusCode::OK);
+    let iam_payload = response_json(iam_response).await;
+    assert_eq!(iam_payload["current_user"]["email"], "admin@example.com");
+    assert!(
+        iam_payload["navigation"]
+            .as_array()
+            .expect("navigation array")
+            .iter()
+            .any(|item| item["url"] == "/")
+    );
+    assert!(
+        iam_payload["navigation"]
+            .as_array()
+            .expect("navigation array")
+            .iter()
+            .any(|item| item["url"] == "/managers")
+    );
+    assert!(
+        iam_payload["local_menu_items"]
+            .as_array()
+            .expect("menu array")
+            .iter()
+            .any(|item| item["url"] == "/settings")
+    );
+
+    let add_client_response = client
+        .post(format!("{}/client/add", app.address()))
+        .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
+        .body(form_body(vec![
+            ("name", "Alice Admin"),
+            ("email", "alice@example.com"),
+            ("phone", ""),
+        ]))
+        .send()
+        .await
+        .expect("Failed to add client.");
+
+    assert_eq!(add_client_response.status(), StatusCode::CREATED);
+    let created_client = repo
+        .get_client_by_email(&ClientEmail::new("alice@example.com").unwrap(), hub_id())
+        .expect("Client lookup should succeed.")
+        .expect("Created client should exist.");
+    let created_client_id = created_client.id;
+
+    let upload_response = client
+        .post(format!("{}/clients/upload", app.address()))
+        .multipart(
+            multipart::Form::new().part(
+                "csv",
+                multipart::Part::bytes(
+                    b"name,email,phone,tier\nBob Import,bob@example.com,,silver\nInvalid,,,gold\n"
+                        .to_vec(),
+                )
+                .file_name("clients.csv"),
+            ),
+        )
+        .send()
+        .await
+        .expect("Failed to upload clients.");
+
+    assert_eq!(upload_response.status(), StatusCode::OK);
+    let imported_client = repo
+        .get_client_by_email(&ClientEmail::new("bob@example.com").unwrap(), hub_id())
+        .expect("Imported client lookup should succeed.")
+        .expect("Imported client should exist.");
+    let imported_client_with_fields = repo
+        .get_client_by_id(imported_client.id, hub_id())
+        .expect("Imported client-with-fields lookup should succeed.")
+        .expect("Imported client-with-fields should exist.");
+    assert_eq!(
+        imported_client_with_fields
+            .fields
+            .as_ref()
+            .and_then(|fields| fields.get("tier")),
+        Some(&"silver".to_string())
+    );
+
+    let add_manager_response = client
+        .post(format!("{}/managers/add", app.address()))
+        .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
+        .body(form_body(vec![
+            ("name", "Manager One"),
+            ("email", "manager.one@example.com"),
+        ]))
+        .send()
+        .await
+        .expect("Failed to add manager.");
+
+    assert_eq!(add_manager_response.status(), StatusCode::CREATED);
+    let manager = repo
+        .get_manager_by_email(
+            &ManagerEmail::new("manager.one@example.com").unwrap(),
+            hub_id(),
+        )
+        .expect("Manager lookup should succeed.")
+        .expect("Manager should exist.");
+
+    let assign_manager_response = client
+        .post(format!("{}/managers/assign", app.address()))
+        .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
+        .body(form_body(vec![
+            ("manager_id", manager.id.get().to_string()),
+            ("client_ids", created_client_id.get().to_string()),
+            ("client_ids", imported_client.id.get().to_string()),
+        ]))
+        .send()
+        .await
+        .expect("Failed to assign manager.");
+
+    assert_eq!(assign_manager_response.status(), StatusCode::OK);
+
+    let managers_page_response = client
+        .get(format!("{}/managers", app.address()))
+        .send()
+        .await
+        .expect("Failed to request managers page.");
+
+    assert_eq!(managers_page_response.status(), StatusCode::OK);
+    let managers_html = managers_page_response
+        .text()
+        .await
+        .expect("Managers page should be readable.");
+    assert!(managers_html.contains("<title>CRM Managers</title>"));
+
+    let managers_api_response = client
+        .get(format!("{}/api/v1/managers", app.address()))
+        .send()
+        .await
+        .expect("Failed to request managers API.");
+
+    assert_eq!(managers_api_response.status(), StatusCode::OK);
+    let managers_payload = response_json(managers_api_response).await;
+    let manager_item = managers_payload["managers"]
+        .as_array()
+        .expect("Managers payload should be an array.")
+        .iter()
+        .find(|item| item["manager"]["email"] == "manager.one@example.com")
+        .expect("Manager payload should include the created manager.");
+    assert_eq!(
+        manager_item["clients"]
+            .as_array()
+            .expect("Assigned clients array")
+            .len(),
+        2
+    );
+
+    let manager_modal_response = client
+        .get(format!(
+            "{}/api/v1/managers/{}",
+            app.address(),
+            manager.id.get()
+        ))
+        .send()
+        .await
+        .expect("Failed to request manager modal API.");
+
+    assert_eq!(manager_modal_response.status(), StatusCode::OK);
+    let manager_modal_payload = response_json(manager_modal_response).await;
+    assert_eq!(
+        manager_modal_payload["manager"]["email"],
+        "manager.one@example.com"
+    );
+
+    let settings_page_response = client
+        .get(format!("{}/settings", app.address()))
+        .send()
+        .await
+        .expect("Failed to request settings page.");
+
+    assert_eq!(settings_page_response.status(), StatusCode::OK);
+    let settings_html = settings_page_response
+        .text()
+        .await
+        .expect("Settings page should be readable.");
+    assert!(settings_html.contains("<title>CRM Settings</title>"));
+
+    let save_important_fields_response = client
+        .post(format!("{}/important-fields", app.address()))
+        .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
+        .body(form_body(vec![("fields", "Tier\nCity")]))
+        .send()
+        .await
+        .expect("Failed to save important fields.");
+
+    assert_eq!(save_important_fields_response.status(), StatusCode::OK);
+    let stored_fields = repo
+        .list_important_fields(hub_id())
+        .expect("Important fields lookup should succeed.");
+    let stored_field_names: Vec<_> = stored_fields
+        .iter()
+        .map(|field| field.field.as_str().to_string())
+        .collect();
+    assert_eq!(
+        stored_field_names,
+        vec!["City".to_string(), "Tier".to_string()]
+    );
+
+    let important_fields_response = client
+        .get(format!("{}/api/v1/important-fields", app.address()))
+        .send()
+        .await
+        .expect("Failed to request important fields API.");
+
+    assert_eq!(important_fields_response.status(), StatusCode::OK);
+    let important_fields_payload = response_json(important_fields_response).await;
+    assert_eq!(important_fields_payload["fields_text"], "City\nTier");
+
+    let directory_response = client
+        .get(format!(
+            "{}/api/v1/client-directory?search=Alice&page=1",
+            app.address()
+        ))
+        .send()
+        .await
+        .expect("Failed to request client directory API.");
+
+    assert_eq!(directory_response.status(), StatusCode::OK);
+    let directory_payload = response_json(directory_response).await;
+    assert_eq!(directory_payload["search_query"], "Alice");
+    assert_eq!(
+        directory_payload["clients"]["items"]
+            .as_array()
+            .expect("Directory items should be an array.")
+            .len(),
+        1
+    );
+
+    let client_page_response = client
+        .get(format!(
+            "{}/client/{}",
+            app.address(),
+            created_client_id.get()
+        ))
+        .send()
+        .await
+        .expect("Failed to request client page.");
+
+    assert_eq!(client_page_response.status(), StatusCode::OK);
+    let client_html = client_page_response
+        .text()
+        .await
+        .expect("Client page should be readable.");
+    assert!(client_html.contains("<title>CRM Client</title>"));
+
+    let save_client_response = client
+        .post(format!(
+            "{}/client/{}/save",
+            app.address(),
+            created_client_id.get()
+        ))
+        .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
+        .body(form_body(vec![
+            ("name", "Alice Updated"),
+            ("email", "alice.updated@example.com"),
+            ("phone", "+1 (415) 555-2671"),
+            ("field", "Tier"),
+            ("value", "gold"),
+            ("field", "City"),
+            ("value", "Paris"),
+        ]))
+        .send()
+        .await
+        .expect("Failed to save client.");
+
+    assert_eq!(save_client_response.status(), StatusCode::OK);
+    let updated_client = repo
+        .get_client_by_id(created_client_id, hub_id())
+        .expect("Updated client lookup should succeed.")
+        .expect("Updated client should exist.");
+    assert_eq!(updated_client.name.as_str(), "Alice Updated");
+    assert_eq!(
+        updated_client.email.as_ref().map(|email| email.as_str()),
+        Some("alice.updated@example.com")
+    );
+    assert_eq!(
+        updated_client.phone.as_ref().map(|phone| phone.as_str()),
+        Some("+14155552671")
+    );
+    assert_eq!(
+        updated_client
+            .fields
+            .as_ref()
+            .and_then(|fields| fields.get("Tier")),
+        Some(&"gold".to_string())
+    );
+
+    let comment_response = client
+        .post(format!(
+            "{}/client/{}/comment",
+            app.address(),
+            created_client_id.get()
+        ))
+        .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
+        .body(form_body(vec![
+            ("subject", ""),
+            ("message", "Met at the expo"),
+            ("event_type", "comment"),
+        ]))
+        .send()
+        .await
+        .expect("Failed to add comment.");
+
+    assert_eq!(comment_response.status(), StatusCode::OK);
+
+    let attachment_response = client
+        .post(format!(
+            "{}/client/{}/attachment",
+            app.address(),
+            created_client_id.get()
+        ))
+        .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
+        .body(form_body(vec![
+            ("text", "Spec"),
+            ("url", "https://example.com/spec.pdf"),
+        ]))
+        .send()
+        .await
+        .expect("Failed to add attachment.");
+
+    assert_eq!(attachment_response.status(), StatusCode::OK);
+
+    let (total_events, events) = repo
+        .list_client_events(ClientEventListQuery::new(created_client_id))
+        .expect("Client events lookup should succeed.");
+    assert_eq!(total_events, 2);
+    assert!(
+        events
+            .iter()
+            .any(|(event, _)| event.event_type == ClientEventType::Comment
+                && event.event_data["text"] == "Met at the expo")
+    );
+    assert!(events.iter().any(
+        |(event, _)| event.event_type == ClientEventType::DocumentLink
+            && event.event_data["url"] == "https://example.com/spec.pdf"
+    ));
+
+    let client_details_response = client
+        .get(format!(
+            "{}/api/v1/clients/{}",
+            app.address(),
+            created_client_id.get()
+        ))
+        .send()
+        .await
+        .expect("Failed to request client details API.");
+
+    assert_eq!(client_details_response.status(), StatusCode::OK);
+    let client_details_payload = response_json(client_details_response).await;
+    assert_eq!(client_details_payload["client"]["name"], "Alice Updated");
+    assert_eq!(
+        client_details_payload["todo_service_url"],
+        "https://todo.pushkind.test"
+    );
+    assert_eq!(
+        client_details_payload["files_service_url"],
+        "https://files.pushkind.test"
+    );
+    assert!(
+        client_details_payload["important_fields"]
+            .as_array()
+            .expect("Important fields array")
+            .iter()
+            .any(|field| field["label"] == "City" && field["value"] == "Paris")
+    );
+    assert!(
+        client_details_payload["documents"]
+            .as_array()
+            .expect("Documents array")
+            .iter()
+            .any(|event| event["event_type"] == "DocumentLink")
+    );
+
+    let integration_clients_response = client
+        .get(format!("{}/api/v1/clients", app.address()))
+        .send()
+        .await
+        .expect("Failed to request integration clients API.");
+
+    assert_eq!(integration_clients_response.status(), StatusCode::OK);
+    let integration_clients_payload = response_json(integration_clients_response).await;
+    assert_eq!(
+        integration_clients_payload
+            .as_array()
+            .expect("Clients list should be an array.")
+            .len(),
+        2
+    );
+
+    let invalid_public_id_response = client
+        .get(format!(
+            "{}/api/v1/clients?public_id=not-a-uuid",
+            app.address()
+        ))
+        .send()
+        .await
+        .expect("Failed to request clients API with invalid public id.");
+
+    assert_eq!(invalid_public_id_response.status(), StatusCode::OK);
+    let invalid_public_id_payload = response_json(invalid_public_id_response).await;
+    assert!(
+        invalid_public_id_payload
+            .as_array()
+            .expect("Clients list should be an array.")
+            .is_empty()
+    );
+
+    let cleanup_response = client
+        .post(format!("{}/settings/cleanup", app.address()))
+        .send()
+        .await
+        .expect("Failed to cleanup clients.");
+
+    assert_eq!(cleanup_response.status(), StatusCode::OK);
+    let (remaining_total, remaining_clients) = repo
+        .list_clients(ClientListQuery::new(hub_id()))
+        .expect("Remaining clients lookup should succeed.");
+    assert_eq!(remaining_total, 0);
+    assert!(remaining_clients.is_empty());
+}
+
+#[ignore = "local-only end-to-end test"]
+#[actix_web::test]
+async fn test_crm_admin_public_id_pagination_and_cross_hub_isolation_story() {
+    let app = common::spawn_app().await;
+    let client = common::build_reqwest_client();
+    let repo = repo(&app);
+
+    common::login_as(
+        &client,
+        app.address(),
+        "admin.scope@example.com",
+        "Scoped Admin",
+        common::HUB_ID,
+        &["crm", "crm_admin"],
+    )
+    .await;
+
+    let own_clients = (1..=(DEFAULT_ITEMS_PER_PAGE + 1))
+        .map(|index| {
+            NewClient::try_new(
+                common::HUB_ID,
+                format!("Paged Client {index:02}"),
+                Some(format!("page{index:02}@example.com")),
+                None,
+                None,
+            )
+            .expect("valid client")
+        })
+        .collect::<Vec<_>>();
+    repo.create_or_replace_clients(&own_clients)
+        .expect("Paged clients should be created.");
+
+    repo.create_or_replace_clients(&[NewClient::try_new(
+        OTHER_HUB_ID,
+        "Other Hub Client".to_string(),
+        Some("outside@example.com".to_string()),
+        None,
+        None,
+    )
+    .expect("valid other-hub client")])
+        .expect("Other-hub client should be created.");
+
+    let target_client = repo
+        .get_client_by_email(&ClientEmail::new("page05@example.com").unwrap(), hub_id())
+        .expect("Target client lookup should succeed.")
+        .expect("Target client should exist.");
+    let target_public_id = target_client
+        .public_id
+        .expect("Seeded clients should have public ids")
+        .to_string();
+    let other_hub_client = repo
+        .get_client_by_email(
+            &ClientEmail::new("outside@example.com").unwrap(),
+            other_hub_id(),
+        )
+        .expect("Other-hub client lookup should succeed.")
+        .expect("Other-hub client should exist.");
+
+    let paged_directory_response = client
+        .get(format!("{}/api/v1/client-directory?page=2", app.address()))
+        .send()
+        .await
+        .expect("Failed to request paginated client directory.");
+
+    assert_eq!(paged_directory_response.status(), StatusCode::OK);
+    let paged_directory_payload = response_json(paged_directory_response).await;
+    assert_eq!(paged_directory_payload["clients"]["page"], 2);
+    let paged_items = paged_directory_payload["clients"]["items"]
+        .as_array()
+        .expect("Directory items should be an array.");
+    assert_eq!(paged_items.len(), 1);
+    assert_eq!(paged_items[0]["email"], "page21@example.com");
+
+    let directory_public_id_response = client
+        .get(format!(
+            "{}/api/v1/client-directory?public_id={target_public_id}",
+            app.address()
+        ))
+        .send()
+        .await
+        .expect("Failed to request directory by public id.");
+
+    assert_eq!(directory_public_id_response.status(), StatusCode::OK);
+    let directory_public_id_payload = response_json(directory_public_id_response).await;
+    let directory_public_id_items = directory_public_id_payload["clients"]["items"]
+        .as_array()
+        .expect("Directory items should be an array.");
+    assert_eq!(directory_public_id_items.len(), 1);
+    assert_eq!(directory_public_id_items[0]["email"], "page05@example.com");
+    assert_eq!(directory_public_id_items[0]["public_id"], target_public_id);
+
+    let integration_public_id_response = client
+        .get(format!(
+            "{}/api/v1/clients?public_id={target_public_id}",
+            app.address()
+        ))
+        .send()
+        .await
+        .expect("Failed to request integration API by public id.");
+
+    assert_eq!(integration_public_id_response.status(), StatusCode::OK);
+    let integration_public_id_payload = response_json(integration_public_id_response).await;
+    let integration_public_id_items = integration_public_id_payload
+        .as_array()
+        .expect("Integration items should be an array.");
+    assert_eq!(integration_public_id_items.len(), 1);
+    assert_eq!(
+        integration_public_id_items[0]["email"],
+        "page05@example.com"
+    );
+
+    let integration_list_response = client
+        .get(format!("{}/api/v1/clients", app.address()))
+        .send()
+        .await
+        .expect("Failed to request integration client list.");
+
+    assert_eq!(integration_list_response.status(), StatusCode::OK);
+    let integration_list_payload = response_json(integration_list_response).await;
+    assert_eq!(
+        integration_list_payload
+            .as_array()
+            .expect("Integration list should be an array.")
+            .len(),
+        DEFAULT_ITEMS_PER_PAGE + 1
+    );
+
+    let other_hub_client_details_response = client
+        .get(format!(
+            "{}/api/v1/clients/{}",
+            app.address(),
+            other_hub_client.id.get()
+        ))
+        .send()
+        .await
+        .expect("Failed to request other-hub client details.");
+
+    assert_eq!(
+        other_hub_client_details_response.status(),
+        StatusCode::NOT_FOUND
+    );
+
+    let other_hub_client_page_response = client
+        .get(format!(
+            "{}/client/{}",
+            app.address(),
+            other_hub_client.id.get()
+        ))
+        .send()
+        .await
+        .expect("Failed to request other-hub client page.");
+
+    assert_eq!(other_hub_client_page_response.status(), StatusCode::OK);
+    assert_eq!(
+        other_hub_client_page_response.url().as_str(),
+        format!("{}/", app.address())
+    );
+
+    let cleanup_response = client
+        .post(format!("{}/settings/cleanup", app.address()))
+        .send()
+        .await
+        .expect("Failed to cleanup current-hub clients.");
+
+    assert_eq!(cleanup_response.status(), StatusCode::OK);
+
+    let (remaining_current_total, remaining_current_clients) = repo
+        .list_clients(ClientListQuery::new(hub_id()))
+        .expect("Current-hub clients lookup should succeed.");
+    assert_eq!(remaining_current_total, 0);
+    assert!(remaining_current_clients.is_empty());
+
+    let (remaining_other_total, remaining_other_clients) = repo
+        .list_clients(ClientListQuery::new(other_hub_id()))
+        .expect("Other-hub clients lookup should succeed.");
+    assert_eq!(remaining_other_total, 1);
+    assert_eq!(
+        remaining_other_clients[0]
+            .email
+            .as_ref()
+            .map(|email| email.as_str()),
+        Some("outside@example.com")
+    );
+}
+
+#[ignore = "local-only end-to-end test"]
+#[actix_web::test]
+async fn test_crm_manager_user_scoped_access_story() {
+    let app = common::spawn_app().await;
+    let client = common::build_reqwest_client();
+    let repo = repo(&app);
+
+    repo.create_or_replace_clients(&[
+        NewClient::try_new(
+            common::HUB_ID,
+            "Assigned Client".to_string(),
+            Some("assigned@example.com".to_string()),
+            None,
+            None,
+        )
+        .unwrap(),
+        NewClient::try_new(
+            common::HUB_ID,
+            "Hidden Client".to_string(),
+            Some("hidden@example.com".to_string()),
+            None,
+            None,
+        )
+        .unwrap(),
+    ])
+    .expect("Seed clients should be created.");
+
+    let assigned_client = repo
+        .get_client_by_email(&ClientEmail::new("assigned@example.com").unwrap(), hub_id())
+        .expect("Assigned client lookup should succeed.")
+        .expect("Assigned client should exist.");
+    let hidden_client = repo
+        .get_client_by_email(&ClientEmail::new("hidden@example.com").unwrap(), hub_id())
+        .expect("Hidden client lookup should succeed.")
+        .expect("Hidden client should exist.");
+
+    let manager = repo
+        .create_or_update_manager(
+            &NewManager::try_new(
+                common::HUB_ID,
+                "Manager User".to_string(),
+                "manager@example.com".to_string(),
+                true,
+            )
+            .unwrap(),
+        )
+        .expect("Manager should be created.");
+    repo.assign_clients_to_manager(manager.id, &[assigned_client.id])
+        .expect("Assigned client should be linked to manager.");
+
+    common::login_as(
+        &client,
+        app.address(),
+        "manager@example.com",
+        "Manager User",
+        common::HUB_ID,
+        &["crm", "crm_manager"],
+    )
+    .await;
+
+    let index_response = client
+        .get(format!("{}/", app.address()))
+        .send()
+        .await
+        .expect("Failed to request CRM index as manager.");
+
+    assert_eq!(index_response.status(), StatusCode::OK);
+
+    let directory_response = client
+        .get(format!("{}/api/v1/client-directory", app.address()))
+        .send()
+        .await
+        .expect("Failed to request manager client directory.");
+
+    assert_eq!(directory_response.status(), StatusCode::OK);
+    let directory_payload = response_json(directory_response).await;
+    let items = directory_payload["clients"]["items"]
+        .as_array()
+        .expect("Directory items should be an array.");
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0]["email"], "assigned@example.com");
+
+    let allowed_client_response = client
+        .get(format!(
+            "{}/api/v1/clients/{}",
+            app.address(),
+            assigned_client.id.get()
+        ))
+        .send()
+        .await
+        .expect("Failed to request assigned client details.");
+
+    assert_eq!(allowed_client_response.status(), StatusCode::OK);
+
+    let hidden_client_response = client
+        .get(format!(
+            "{}/api/v1/clients/{}",
+            app.address(),
+            hidden_client.id.get()
+        ))
+        .send()
+        .await
+        .expect("Failed to request hidden client details.");
+
+    assert_eq!(hidden_client_response.status(), StatusCode::UNAUTHORIZED);
+
+    let redirected_hidden_page_response = client
+        .get(format!(
+            "{}/client/{}",
+            app.address(),
+            hidden_client.id.get()
+        ))
+        .send()
+        .await
+        .expect("Failed to request hidden client page.");
+
+    assert_eq!(redirected_hidden_page_response.status(), StatusCode::OK);
+    assert_eq!(
+        redirected_hidden_page_response.url().as_str(),
+        format!("{}/", app.address())
+    );
+
+    let save_assigned_response = client
+        .post(format!(
+            "{}/client/{}/save",
+            app.address(),
+            assigned_client.id.get()
+        ))
+        .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
+        .body(form_body(vec![
+            ("name", "Assigned Updated"),
+            ("email", "assigned.updated@example.com"),
+            ("phone", "+1 415 555 2671"),
+        ]))
+        .send()
+        .await
+        .expect("Failed to save assigned client.");
+
+    assert_eq!(save_assigned_response.status(), StatusCode::OK);
+    let updated_assigned = repo
+        .get_client_by_id(assigned_client.id, hub_id())
+        .expect("Updated assigned client lookup should succeed.")
+        .expect("Updated assigned client should exist.");
+    assert_eq!(updated_assigned.name.as_str(), "Assigned Updated");
+
+    let comment_assigned_response = client
+        .post(format!(
+            "{}/client/{}/comment",
+            app.address(),
+            assigned_client.id.get()
+        ))
+        .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
+        .body(form_body(vec![
+            ("subject", ""),
+            ("message", "Assigned-only note"),
+            ("event_type", "comment"),
+        ]))
+        .send()
+        .await
+        .expect("Failed to add comment to assigned client.");
+
+    assert_eq!(comment_assigned_response.status(), StatusCode::OK);
+
+    let save_hidden_response = client
+        .post(format!(
+            "{}/client/{}/save",
+            app.address(),
+            hidden_client.id.get()
+        ))
+        .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
+        .body(form_body(vec![
+            ("name", "Should Fail"),
+            ("email", "hidden@example.com"),
+            ("phone", ""),
+        ]))
+        .send()
+        .await
+        .expect("Failed to attempt hidden client save.");
+
+    assert_eq!(save_hidden_response.status(), StatusCode::FORBIDDEN);
+
+    let comment_hidden_response = client
+        .post(format!(
+            "{}/client/{}/comment",
+            app.address(),
+            hidden_client.id.get()
+        ))
+        .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
+        .body(form_body(vec![
+            ("subject", ""),
+            ("message", "Should be blocked"),
+            ("event_type", "comment"),
+        ]))
+        .send()
+        .await
+        .expect("Failed to attempt hidden client comment.");
+
+    assert_eq!(comment_hidden_response.status(), StatusCode::FORBIDDEN);
+
+    let attachment_hidden_response = client
+        .post(format!(
+            "{}/client/{}/attachment",
+            app.address(),
+            hidden_client.id.get()
+        ))
+        .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
+        .body(form_body(vec![
+            ("text", "Blocked attachment"),
+            ("url", "https://example.com/blocked.pdf"),
+        ]))
+        .send()
+        .await
+        .expect("Failed to attempt hidden client attachment.");
+
+    assert_eq!(attachment_hidden_response.status(), StatusCode::FORBIDDEN);
+
+    let managers_page_response = client
+        .get(format!("{}/managers", app.address()))
+        .send()
+        .await
+        .expect("Failed to request managers page as manager.");
+
+    assert_eq!(managers_page_response.status(), StatusCode::OK);
+    assert_eq!(
+        managers_page_response.url().as_str(),
+        format!("{}/na", app.address())
+    );
+}
+
+#[ignore = "local-only end-to-end test"]
+#[actix_web::test]
+async fn test_crm_admin_manager_assignment_replacement_and_not_found_story() {
+    let app = common::spawn_app().await;
+    let client = common::build_reqwest_client();
+    let repo = repo(&app);
+
+    common::login_as(
+        &client,
+        app.address(),
+        "admin.assignment@example.com",
+        "Assignment Admin",
+        common::HUB_ID,
+        &["crm", "crm_admin"],
+    )
+    .await;
+
+    repo.create_or_replace_clients(&[
+        NewClient::try_new(
+            common::HUB_ID,
+            "First Assigned".to_string(),
+            Some("first.assigned@example.com".to_string()),
+            None,
+            None,
+        )
+        .unwrap(),
+        NewClient::try_new(
+            common::HUB_ID,
+            "Second Assigned".to_string(),
+            Some("second.assigned@example.com".to_string()),
+            None,
+            None,
+        )
+        .unwrap(),
+        NewClient::try_new(
+            common::HUB_ID,
+            "Replacement Assigned".to_string(),
+            Some("replacement.assigned@example.com".to_string()),
+            None,
+            None,
+        )
+        .unwrap(),
+        NewClient::try_new(
+            OTHER_HUB_ID,
+            "Cross Hub Assigned".to_string(),
+            Some("cross-hub.assigned@example.com".to_string()),
+            None,
+            None,
+        )
+        .unwrap(),
+    ])
+    .expect("Seed clients should be created.");
+
+    let first_client = repo
+        .get_client_by_email(
+            &ClientEmail::new("first.assigned@example.com").unwrap(),
+            hub_id(),
+        )
+        .expect("First client lookup should succeed.")
+        .expect("First client should exist.");
+    let second_client = repo
+        .get_client_by_email(
+            &ClientEmail::new("second.assigned@example.com").unwrap(),
+            hub_id(),
+        )
+        .expect("Second client lookup should succeed.")
+        .expect("Second client should exist.");
+    let replacement_client = repo
+        .get_client_by_email(
+            &ClientEmail::new("replacement.assigned@example.com").unwrap(),
+            hub_id(),
+        )
+        .expect("Replacement client lookup should succeed.")
+        .expect("Replacement client should exist.");
+    let cross_hub_client = repo
+        .get_client_by_email(
+            &ClientEmail::new("cross-hub.assigned@example.com").unwrap(),
+            other_hub_id(),
+        )
+        .expect("Cross-hub client lookup should succeed.")
+        .expect("Cross-hub client should exist.");
+
+    let add_manager_response = client
+        .post(format!("{}/managers/add", app.address()))
+        .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
+        .body(form_body(vec![
+            ("name", "Replacement Manager"),
+            ("email", "replacement.manager@example.com"),
+        ]))
+        .send()
+        .await
+        .expect("Failed to add manager.");
+
+    assert_eq!(add_manager_response.status(), StatusCode::CREATED);
+    let manager = repo
+        .get_manager_by_email(
+            &ManagerEmail::new("replacement.manager@example.com").unwrap(),
+            hub_id(),
+        )
+        .expect("Manager lookup should succeed.")
+        .expect("Manager should exist.");
+
+    let first_assignment_response = client
+        .post(format!("{}/managers/assign", app.address()))
+        .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
+        .body(form_body(vec![
+            ("manager_id", manager.id.get().to_string()),
+            ("client_ids", first_client.id.get().to_string()),
+            ("client_ids", second_client.id.get().to_string()),
+        ]))
+        .send()
+        .await
+        .expect("Failed to assign initial clients.");
+
+    assert_eq!(first_assignment_response.status(), StatusCode::OK);
+
+    let initial_modal_response = client
+        .get(format!(
+            "{}/api/v1/managers/{}",
+            app.address(),
+            manager.id.get()
+        ))
+        .send()
+        .await
+        .expect("Failed to request initial manager modal.");
+
+    assert_eq!(initial_modal_response.status(), StatusCode::OK);
+    let initial_modal_payload = response_json(initial_modal_response).await;
+    let initial_client_emails = initial_modal_payload["clients"]
+        .as_array()
+        .expect("Manager modal clients should be an array.")
+        .iter()
+        .map(|client| client["email"].as_str().unwrap().to_string())
+        .collect::<Vec<_>>();
+    assert_eq!(initial_client_emails.len(), 2);
+    assert!(initial_client_emails.contains(&"first.assigned@example.com".to_string()));
+    assert!(initial_client_emails.contains(&"second.assigned@example.com".to_string()));
+
+    let replacement_assignment_response = client
+        .post(format!("{}/managers/assign", app.address()))
+        .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
+        .body(form_body(vec![
+            ("manager_id", manager.id.get().to_string()),
+            ("client_ids", replacement_client.id.get().to_string()),
+        ]))
+        .send()
+        .await
+        .expect("Failed to replace manager assignments.");
+
+    assert_eq!(replacement_assignment_response.status(), StatusCode::OK);
+
+    let replacement_modal_response = client
+        .get(format!(
+            "{}/api/v1/managers/{}",
+            app.address(),
+            manager.id.get()
+        ))
+        .send()
+        .await
+        .expect("Failed to request replacement manager modal.");
+
+    assert_eq!(replacement_modal_response.status(), StatusCode::OK);
+    let replacement_modal_payload = response_json(replacement_modal_response).await;
+    let replacement_clients = replacement_modal_payload["clients"]
+        .as_array()
+        .expect("Manager modal clients should be an array.");
+    assert_eq!(replacement_clients.len(), 1);
+    assert_eq!(
+        replacement_clients[0]["email"],
+        "replacement.assigned@example.com"
+    );
+
+    let cross_hub_assignment_response = client
+        .post(format!("{}/managers/assign", app.address()))
+        .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
+        .body(form_body(vec![
+            ("manager_id", manager.id.get().to_string()),
+            ("client_ids", cross_hub_client.id.get().to_string()),
+        ]))
+        .send()
+        .await
+        .expect("Failed to attempt cross-hub assignment.");
+
+    assert_eq!(
+        cross_hub_assignment_response.status(),
+        StatusCode::BAD_REQUEST
+    );
+    let cross_hub_assignment_payload = response_json(cross_hub_assignment_response).await;
+    assert_eq!(
+        cross_hub_assignment_payload["message"],
+        "Некорректный список клиентов"
+    );
+
+    let missing_manager_response = client
+        .post(format!("{}/managers/assign", app.address()))
+        .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
+        .body(form_body(vec![
+            ("manager_id".to_string(), "999999".to_string()),
+            (
+                "client_ids".to_string(),
+                replacement_client.id.get().to_string(),
+            ),
+        ]))
+        .send()
+        .await
+        .expect("Failed to attempt missing-manager assignment.");
+
+    assert_eq!(missing_manager_response.status(), StatusCode::NOT_FOUND);
+    let missing_manager_payload = response_json(missing_manager_response).await;
+    assert_eq!(missing_manager_payload["message"], "Менеджер не найден.");
+}
+
+#[ignore = "local-only end-to-end test"]
+#[actix_web::test]
+async fn test_crm_client_details_sanitize_and_order_events_story() {
+    let app = common::spawn_app().await;
+    let client = common::build_reqwest_client();
+    let repo = repo(&app);
+
+    common::login_as(
+        &client,
+        app.address(),
+        "admin.client@example.com",
+        "Client Admin",
+        common::HUB_ID,
+        &["crm", "crm_admin"],
+    )
+    .await;
+
+    let add_client_response = client
+        .post(format!("{}/client/add", app.address()))
+        .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
+        .body(form_body(vec![
+            ("name", "Detail Story Client"),
+            ("email", "detail.story@example.com"),
+            ("phone", ""),
+        ]))
+        .send()
+        .await
+        .expect("Failed to add detail client.");
+
+    assert_eq!(add_client_response.status(), StatusCode::CREATED);
+    let detail_client = repo
+        .get_client_by_email(
+            &ClientEmail::new("detail.story@example.com").unwrap(),
+            hub_id(),
+        )
+        .expect("Detail client lookup should succeed.")
+        .expect("Detail client should exist.");
+
+    let add_manager_response = client
+        .post(format!("{}/managers/add", app.address()))
+        .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
+        .body(form_body(vec![
+            ("name", "Detail Manager"),
+            ("email", "detail.manager@example.com"),
+        ]))
+        .send()
+        .await
+        .expect("Failed to add detail manager.");
+
+    assert_eq!(add_manager_response.status(), StatusCode::CREATED);
+    let detail_manager = repo
+        .get_manager_by_email(
+            &ManagerEmail::new("detail.manager@example.com").unwrap(),
+            hub_id(),
+        )
+        .expect("Detail manager lookup should succeed.")
+        .expect("Detail manager should exist.");
+
+    let assign_manager_response = client
+        .post(format!("{}/managers/assign", app.address()))
+        .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
+        .body(form_body(vec![
+            ("manager_id", detail_manager.id.get().to_string()),
+            ("client_ids", detail_client.id.get().to_string()),
+        ]))
+        .send()
+        .await
+        .expect("Failed to assign detail manager.");
+
+    assert_eq!(assign_manager_response.status(), StatusCode::OK);
+
+    let email_event_response = client
+        .post(format!(
+            "{}/client/{}/comment",
+            app.address(),
+            detail_client.id.get()
+        ))
+        .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
+        .body(form_body(vec![
+            ("subject", "Quarterly Follow-up"),
+            ("message", "Please review the latest deck"),
+            ("event_type", "email"),
+        ]))
+        .send()
+        .await
+        .expect("Failed to add email event.");
+
+    assert_eq!(email_event_response.status(), StatusCode::OK);
+
+    sleep(Duration::from_secs(1)).await;
+
+    let comment_response = client
+        .post(format!(
+            "{}/client/{}/comment",
+            app.address(),
+            detail_client.id.get()
+        ))
+        .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
+        .body(form_body(vec![
+            ("subject", ""),
+            ("message", "<script>alert(1)</script><b>Met at the expo</b>"),
+            ("event_type", "comment"),
+        ]))
+        .send()
+        .await
+        .expect("Failed to add sanitized comment.");
+
+    assert_eq!(comment_response.status(), StatusCode::OK);
+
+    sleep(Duration::from_secs(1)).await;
+
+    let attachment_response = client
+        .post(format!(
+            "{}/client/{}/attachment",
+            app.address(),
+            detail_client.id.get()
+        ))
+        .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
+        .body(form_body(vec![
+            ("text", "Expo Notes"),
+            ("url", "https://example.com/expo-notes.pdf"),
+        ]))
+        .send()
+        .await
+        .expect("Failed to add detail attachment.");
+
+    assert_eq!(attachment_response.status(), StatusCode::OK);
+
+    let client_details_response = client
+        .get(format!(
+            "{}/api/v1/clients/{}",
+            app.address(),
+            detail_client.id.get()
+        ))
+        .send()
+        .await
+        .expect("Failed to request detail client payload.");
+
+    assert_eq!(client_details_response.status(), StatusCode::OK);
+    let client_details_payload = response_json(client_details_response).await;
+    assert!(
+        client_details_payload["managers"]
+            .as_array()
+            .expect("Managers array should exist.")
+            .iter()
+            .any(|manager| manager["email"] == "detail.manager@example.com")
+    );
+    assert_eq!(client_details_payload["total_events"], 3);
+
+    let ordered_events = client_details_payload["events"]
+        .as_array()
+        .expect("Events array should exist.");
+    assert_eq!(ordered_events.len(), 3);
+    assert_eq!(ordered_events[0]["event_type"], "DocumentLink");
+    assert_eq!(ordered_events[1]["event_type"], "Comment");
+    assert_eq!(ordered_events[2]["event_type"], "Email");
+
+    let sanitized_comment = ordered_events[1]["event_data"]["text"]
+        .as_str()
+        .expect("Comment text should be a string.");
+    assert!(!sanitized_comment.contains("<script"));
+    assert!(sanitized_comment.contains("Met at the expo"));
+    assert_eq!(
+        ordered_events[2]["event_data"]["subject"],
+        "Quarterly Follow-up"
+    );
+    assert_eq!(
+        ordered_events[2]["event_data"]["text"],
+        "Please review the latest deck"
+    );
+    assert!(
+        client_details_payload["documents"]
+            .as_array()
+            .expect("Documents array should exist.")
+            .iter()
+            .any(|event| event["event_data"]["url"] == "https://example.com/expo-notes.pdf")
+    );
+}
+
+#[ignore = "local-only end-to-end test"]
+#[actix_web::test]
+async fn test_crm_worker_event_ingestion_story() {
+    let app = common::spawn_app().await;
+    let repo = repo(&app);
+
+    repo.create_or_replace_clients(&[NewClient::try_new(
+        common::HUB_ID,
+        "Worker Client".to_string(),
+        Some("worker.client@example.com".to_string()),
+        None,
+        None,
+    )
+    .unwrap()])
+        .expect("Worker client should be created.");
+
+    let worker_client = repo
+        .get_client_by_email(
+            &ClientEmail::new("worker.client@example.com").unwrap(),
+            hub_id(),
+        )
+        .expect("Worker client lookup should succeed.")
+        .expect("Worker client should exist.");
+    let worker_public_id = worker_client
+        .public_id
+        .expect("Worker client should have a public id")
+        .to_string();
+
+    check_events_bin::process_reply_message(
+        ZMQReplyMessage {
+            hub_id: common::HUB_ID,
+            email: "worker.client@example.com".to_string(),
+            message: "<script>alert(1)</script><b>Reply body</b>".to_string(),
+            subject: Some("RE: CRM".to_string()),
+        },
+        repo.clone(),
+    )
+    .expect("Reply message processing should succeed.");
+
+    check_events_bin::process_unsubscribe_message(
+        ZMQUnsubscribeMessage {
+            hub_id: common::HUB_ID,
+            email: "worker.client@example.com".to_string(),
+            reason: Some("No longer interested".to_string()),
+        },
+        repo.clone(),
+    )
+    .expect("Unsubscribe processing should succeed.");
+
+    check_events_bin::process_task_message(
+        ZmqTask {
+            public_id: "task-123".to_string(),
+            hub_id: common::HUB_ID,
+            title: "Task from worker".to_string(),
+            priority: TaskPriority::High,
+            status: TaskStatus::Pending,
+            created_at: Utc::now().naive_utc(),
+            updated_at: Utc::now().naive_utc(),
+            due_date: None,
+            completed_at: None,
+            author: ZmqTaskAuthor {
+                name: "Task Manager".to_string(),
+                email: "task.manager@example.com".to_string(),
+            },
+            client: Some(ZmqTaskClient {
+                name: "Worker Client".to_string(),
+                public_id: worker_public_id,
+            }),
+            assignee: Some(ZmqTaskAssignee {
+                name: "Assignee User".to_string(),
+                email: "assignee@example.com".to_string(),
+            }),
+            description: Some("Follow up with the client".to_string()),
+            track: Some("CRM".to_string()),
+        },
+        repo.clone(),
+    )
+    .expect("Task message processing should succeed.");
+
+    let (total_events, events) = repo
+        .list_client_events(ClientEventListQuery::new(worker_client.id))
+        .expect("Worker events lookup should succeed.");
+    assert_eq!(total_events, 3);
+    assert!(events.iter().any(|(event, _)| {
+        event.event_type == ClientEventType::Reply
+            && event.event_data["subject"] == "RE: CRM"
+            && event.event_data["text"]
+                .as_str()
+                .is_some_and(|text| !text.contains("<script") && text.contains("Reply body"))
+    }));
+    assert!(events.iter().any(|(event, _)| {
+        event.event_type == ClientEventType::Unsubscribed
+            && event.event_data["text"] == "No longer interested"
+    }));
+    assert!(events.iter().any(|(event, _)| {
+        event.event_type == ClientEventType::Task
+            && event.event_data["public_id"] == "task-123"
+            && event.event_data["subject"] == "Task from worker"
+            && event.event_data["text"] == "Follow up with the client"
+            && event.event_data["track"] == "CRM"
+            && event.event_data["priority"] == "High"
+            && event.event_data["status"] == "Pending"
+            && event.event_data["assignee"]["email"] == "assignee@example.com"
+    }));
+}
+
+#[ignore = "local-only end-to-end test"]
+#[actix_web::test]
+async fn test_crm_basic_user_and_admin_only_access_stories() {
+    let app = common::spawn_app().await;
+    let repo = repo(&app);
+
+    repo.create_or_replace_clients(&[NewClient::try_new(
+        common::HUB_ID,
+        "Visible Through Integration API".to_string(),
+        Some("viewer-seed@example.com".to_string()),
+        None,
+        Some(BTreeMap::from([(
+            String::from("tier"),
+            String::from("bronze"),
+        )])),
+    )
+    .unwrap()])
+        .expect("Seed client should be created.");
+
+    let basic_client = common::build_reqwest_client();
+    common::login_as(
+        &basic_client,
+        app.address(),
+        "viewer@example.com",
+        "Basic Viewer",
+        common::HUB_ID,
+        &["crm"],
+    )
+    .await;
+
+    let basic_index_response = basic_client
+        .get(format!("{}/", app.address()))
+        .send()
+        .await
+        .expect("Failed to request CRM index as basic user.");
+
+    assert_eq!(basic_index_response.status(), StatusCode::OK);
+
+    let basic_directory_response = basic_client
+        .get(format!("{}/api/v1/client-directory", app.address()))
+        .send()
+        .await
+        .expect("Failed to request client directory as basic user.");
+
+    assert_eq!(basic_directory_response.status(), StatusCode::OK);
+    let basic_directory_payload = response_json(basic_directory_response).await;
+    assert!(
+        basic_directory_payload["clients"]["items"]
+            .as_array()
+            .expect("Directory items should be an array.")
+            .is_empty()
+    );
+
+    let integration_list_response = basic_client
+        .get(format!("{}/api/v1/clients", app.address()))
+        .send()
+        .await
+        .expect("Failed to request integration client list as basic user.");
+
+    assert_eq!(integration_list_response.status(), StatusCode::OK);
+    let integration_list_payload = response_json(integration_list_response).await;
+    assert_eq!(
+        integration_list_payload
+            .as_array()
+            .expect("Integration list should be an array.")
+            .len(),
+        1
+    );
+
+    let forbidden_add_client_response = basic_client
+        .post(format!("{}/client/add", app.address()))
+        .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
+        .body(form_body(vec![
+            ("name", "Blocked"),
+            ("email", "blocked@example.com"),
+            ("phone", ""),
+        ]))
+        .send()
+        .await
+        .expect("Failed to attempt add client as basic user.");
+
+    assert_eq!(
+        forbidden_add_client_response.status(),
+        StatusCode::FORBIDDEN
+    );
+
+    let basic_managers_response = basic_client
+        .get(format!("{}/managers", app.address()))
+        .send()
+        .await
+        .expect("Failed to request managers page as basic user.");
+
+    assert_eq!(basic_managers_response.status(), StatusCode::OK);
+    assert_eq!(
+        basic_managers_response.url().as_str(),
+        format!("{}/na", app.address())
+    );
+
+    let admin_only_client = common::build_reqwest_client();
+    common::login_as(
+        &admin_only_client,
+        app.address(),
+        "admin-only@example.com",
+        "Admin Only",
+        common::HUB_ID,
+        &["crm_admin"],
+    )
+    .await;
+
+    let admin_only_iam_response = admin_only_client
+        .get(format!("{}/api/v1/iam", app.address()))
+        .send()
+        .await
+        .expect("Failed to request IAM as admin-only user.");
+
+    assert_eq!(admin_only_iam_response.status(), StatusCode::OK);
+    let admin_only_iam_payload = response_json(admin_only_iam_response).await;
+    assert!(
+        !admin_only_iam_payload["navigation"]
+            .as_array()
+            .expect("navigation array")
+            .iter()
+            .any(|item| item["url"] == "/")
+    );
+    assert!(
+        admin_only_iam_payload["navigation"]
+            .as_array()
+            .expect("navigation array")
+            .iter()
+            .any(|item| item["url"] == "/managers")
+    );
+
+    let admin_only_index_response = admin_only_client
+        .get(format!("{}/", app.address()))
+        .send()
+        .await
+        .expect("Failed to request CRM index as admin-only user.");
+
+    assert_eq!(admin_only_index_response.status(), StatusCode::OK);
+    assert_eq!(
+        admin_only_index_response.url().as_str(),
+        format!("{}/na", app.address())
+    );
+
+    let admin_only_managers_response = admin_only_client
+        .get(format!("{}/managers", app.address()))
+        .send()
+        .await
+        .expect("Failed to request managers page as admin-only user.");
+
+    assert_eq!(admin_only_managers_response.status(), StatusCode::OK);
+    let admin_only_managers_html = admin_only_managers_response
+        .text()
+        .await
+        .expect("Managers page should be readable.");
+    assert!(admin_only_managers_html.contains("<title>CRM Managers</title>"));
+
+    let admin_only_directory_response = admin_only_client
+        .get(format!("{}/api/v1/client-directory", app.address()))
+        .send()
+        .await
+        .expect("Failed to request directory API as admin-only user.");
+
+    assert_eq!(
+        admin_only_directory_response.status(),
+        StatusCode::UNAUTHORIZED
+    );
+
+    let admin_only_integration_response = admin_only_client
+        .get(format!("{}/api/v1/clients", app.address()))
+        .send()
+        .await
+        .expect("Failed to request integration API as admin-only user.");
+
+    assert_eq!(admin_only_integration_response.status(), StatusCode::OK);
+    let admin_only_integration_payload = response_json(admin_only_integration_response).await;
+    let admin_only_clients = admin_only_integration_payload
+        .as_array()
+        .expect("Integration list should be an array.");
+    assert_eq!(admin_only_clients.len(), 1);
+    assert_eq!(admin_only_clients[0]["email"], "viewer-seed@example.com");
+}
+
+#[ignore = "local-only end-to-end test"]
+#[actix_web::test]
+async fn test_crm_basic_user_is_blocked_from_admin_management_apis_and_mutations() {
+    let app = common::spawn_app().await;
+    let client = common::build_reqwest_client();
+
+    common::login_as(
+        &client,
+        app.address(),
+        "viewer.limits@example.com",
+        "Viewer Limits",
+        common::HUB_ID,
+        &["crm"],
+    )
+    .await;
+
+    let managers_api_response = client
+        .get(format!("{}/api/v1/managers", app.address()))
+        .send()
+        .await
+        .expect("Failed to request managers API as basic user.");
+
+    assert_eq!(managers_api_response.status(), StatusCode::UNAUTHORIZED);
+
+    let important_fields_api_response = client
+        .get(format!("{}/api/v1/important-fields", app.address()))
+        .send()
+        .await
+        .expect("Failed to request important-fields API as basic user.");
+
+    assert_eq!(
+        important_fields_api_response.status(),
+        StatusCode::UNAUTHORIZED
+    );
+
+    let upload_response = client
+        .post(format!("{}/clients/upload", app.address()))
+        .multipart(
+            multipart::Form::new().part(
+                "csv",
+                multipart::Part::bytes(
+                    b"name,email\nBlocked Upload,blocked.upload@example.com\n".to_vec(),
+                )
+                .file_name("clients.csv"),
+            ),
+        )
+        .send()
+        .await
+        .expect("Failed to attempt client upload as basic user.");
+
+    assert_eq!(upload_response.status(), StatusCode::FORBIDDEN);
+
+    let add_manager_response = client
+        .post(format!("{}/managers/add", app.address()))
+        .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
+        .body(form_body(vec![
+            ("name", "Blocked Manager"),
+            ("email", "blocked.manager@example.com"),
+        ]))
+        .send()
+        .await
+        .expect("Failed to attempt add manager as basic user.");
+
+    assert_eq!(add_manager_response.status(), StatusCode::FORBIDDEN);
+
+    let assign_manager_response = client
+        .post(format!("{}/managers/assign", app.address()))
+        .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
+        .body(form_body(vec![("manager_id", "1"), ("client_ids", "1")]))
+        .send()
+        .await
+        .expect("Failed to attempt assign manager as basic user.");
+
+    assert_eq!(assign_manager_response.status(), StatusCode::FORBIDDEN);
+
+    let save_important_fields_response = client
+        .post(format!("{}/important-fields", app.address()))
+        .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
+        .body(form_body(vec![("fields", "Blocked Field")]))
+        .send()
+        .await
+        .expect("Failed to attempt save important fields as basic user.");
+
+    assert_eq!(
+        save_important_fields_response.status(),
+        StatusCode::FORBIDDEN
+    );
+
+    let cleanup_response = client
+        .post(format!("{}/settings/cleanup", app.address()))
+        .send()
+        .await
+        .expect("Failed to attempt cleanup as basic user.");
+
+    assert_eq!(cleanup_response.status(), StatusCode::FORBIDDEN);
+}


### PR DESCRIPTION
## Summary
- expand the CRM end-to-end harness and user-story coverage
- add explicit admin-only coverage for `GET /api/v1/clients`
- align the route documentation with the actual `crm` or `crm_admin` authorization contract

## Why
`GET /api/v1/clients` was already implemented to allow both `crm` and `crm_admin`, but the end-to-end suite did not lock that behavior in and the route comment still implied that `crm` alone was required. That left a contract gap around admin-only integrations.

## User impact
Admin-only CRM users can now rely on `GET /api/v1/clients` remaining available, and the broader e2e suite now covers the remaining high-value CRM user stories around scoping, manager assignment, event ingestion, and role-gated mutations.

## Root cause
The service-layer authorization allowed admin-only access, but the HTTP-level regression coverage was missing and the route documentation had drifted from the implementation.

## Validation
- `cargo test --all-features --test e2e test_crm_basic_user_and_admin_only_access_stories -- --ignored`
- `cargo test --all-features --test e2e -- --ignored`
- `cargo test --all-features --all-targets`